### PR TITLE
Improve test for `FixedSizeMatrix`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,13 +2,19 @@ using Test
 using FixedSizeArrays
 
 @testset "FixedSizeArrays" begin
-    v = FixedSizeVector{Float64}(undef, 3)
-    @test length(v) == 3
-    v .= 1:3
-    @test v == 1:3
 
-    m = FixedSizeMatrix{Float64}(undef, 3, 3)
-    @test length(m) == 9
-    m[:] .= 1:9
-    @test m[:] == 1:9
+    @testset "FixedSizeVector" begin
+        v = FixedSizeVector{Float64}(undef, 3)
+        @test length(v) == 3
+        v .= 1:3
+        @test v == 1:3
+    end
+
+    @testset "FixedSizeMatrix" begin
+        m = FixedSizeMatrix{Float64}(undef, 3, 3)
+        m_ref = reshape(1:9, size(m))
+        @test length(m) == 9
+        m .= m_ref
+        @test m == m_ref
+    end
 end


### PR DESCRIPTION
The previous tests were flattening the matrix before setting/accessing the elements, thus not really exercising the 2D indexing of the new data type.