### PR TITLE
specialize `similar`

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -20,4 +20,8 @@ Base.@propagate_inbounds Base.setindex!(A::FixedSizeArray, v, i::Int) = A.mem[i]
 
 Base.size(a::FixedSizeArray) = getfield(a, :size)
 
+function Base.similar(::FixedSizeArray, ::Type{S}, size::NTuple{N,Int}) where {S,N}
+    FixedSizeArray{S,N}(undef, size...)
+end
+
 end # module FixedSizeArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,11 @@ using FixedSizeArrays
         @test length(v) == 3
         v .= 1:3
         @test v == 1:3
+        @test typeof(v) == typeof(similar(v)) == FixedSizeVector{Float64}
+        @test similar(v, Int) isa FixedSizeVector{Int}
+        @test eltype(similar(v, Int)) == Int
+        @test copy(v) isa FixedSizeVector{Float64}
+        @test zero(v) isa FixedSizeVector{Float64}
     end
 
     @testset "FixedSizeMatrix" begin
@@ -16,5 +21,10 @@ using FixedSizeArrays
         @test length(m) == 9
         m .= m_ref
         @test m == m_ref
+        @test typeof(m) == typeof(similar(m)) == FixedSizeMatrix{Float64}
+        @test similar(m, Int) isa FixedSizeMatrix{Int}
+        @test eltype(similar(m, Int)) == Int
+        @test copy(m) isa FixedSizeMatrix{Float64}
+        @test zero(m) isa FixedSizeMatrix{Float64}
     end
 end


### PR DESCRIPTION
Now `similar` will be able to return `FixedSizeArray`s instead of `Array`s.

Updates #4