### PR TITLE
revamp constructors

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -5,13 +5,25 @@ export FixedSizeArray, FixedSizeVector, FixedSizeMatrix
 struct FixedSizeArray{T,N} <: DenseArray{T,N}
     mem::Memory{T}
     size::NTuple{N,Int}
+    function FixedSizeArray{T,N}(mem::Memory{T}, size::NTuple{N,Int}) where {T,N}
+        new{T,N}(mem, size)
+    end
 end
 
 const FixedSizeVector{T} = FixedSizeArray{T,1}
 const FixedSizeMatrix{T} = FixedSizeArray{T,2}
 
+function FixedSizeArray{T,N}(::UndefInitializer, size::NTuple{N,Int}) where {T,N}
+    FixedSizeArray{T,N}(Memory{T}(undef, prod(size)), size)
+end
 function FixedSizeArray{T,N}(::UndefInitializer, size::Vararg{Int,N}) where {T,N}
-    return FixedSizeArray(Memory{T}(undef, prod(size)), size)
+    FixedSizeArray{T,N}(undef, size)
+end
+function FixedSizeArray{T}(::UndefInitializer, size::Vararg{Int,N}) where {T,N}
+    FixedSizeArray{T,N}(undef, size)
+end
+function FixedSizeArray{T}(::UndefInitializer, size::NTuple{N,Int}) where {T,N}
+    FixedSizeArray{T,N}(undef, size)
 end
 
 Base.IndexStyle(::Type{<:FixedSizeArray}) = IndexLinear()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ using FixedSizeArrays
         @test eltype(similar(v, Int)) == Int
         @test copy(v) isa FixedSizeVector{Float64}
         @test zero(v) isa FixedSizeVector{Float64}
+        @test similar(FixedSizeVector{Int}, (2,)) isa FixedSizeVector{Int}
+        @test similar(FixedSizeArray{Int}, (2,)) isa FixedSizeVector{Int}
+        @test FixedSizeArray{Int}(undef, 2) isa FixedSizeVector{Int}
     end
 
     @testset "FixedSizeMatrix" begin
@@ -26,5 +29,8 @@ using FixedSizeArrays
         @test eltype(similar(m, Int)) == Int
         @test copy(m) isa FixedSizeMatrix{Float64}
         @test zero(m) isa FixedSizeMatrix{Float64}
+        @test similar(FixedSizeMatrix{Int}, (2, 3)) isa FixedSizeMatrix{Int}
+        @test similar(FixedSizeArray{Int}, (2, 3)) isa FixedSizeMatrix{Int}
+        @test FixedSizeArray{Int}(undef, 2, 3) isa FixedSizeMatrix{Int}
     end
 end


### PR DESCRIPTION
Goals:

* support `undef` constructor methods with incompletely specified type, lacking dimensionality, e.g., `FixedArray{Int}(undef, 3, 7)`

* support `undef` constructor methods with `size` passed as tuple instead of as `Vararg`

To make this possible, it was necessary to get rid of the automatically generated inner constructor methods, to prevent ambiguity.

A specific reason why these changes are necessary is that some methods of `similar` defined in `Base` expect such constructors to exist.