### PR TITLE
specialize `isassigned` for performance

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -36,6 +36,8 @@ function Base.similar(::FixedSizeArray, ::Type{S}, size::NTuple{N,Int}) where {S
     FixedSizeArray{S,N}(undef, size...)
 end
 
+Base.isassigned(a::FixedSizeArray, i::Int) = isassigned(a.mem, i)
+
 # broadcasting
 
 function Base.BroadcastStyle(::Type{<:FixedSizeArray})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,4 +91,28 @@ using FixedSizeArrays
             @test (@inferred (m33 .+ m33)) isa FixedSizeMatrix{Int}
         end
     end
+
+    @testset "`isassigned`" begin
+        for dim_count ∈ 1:3
+            for elem_type ∈ (Int, FixedSizeMatrix{Nothing})
+                size = ntuple(Returns(3), dim_count)
+                a = FixedSizeArray{elem_type, dim_count}(undef, size)
+                for i_style ∈ (IndexLinear(), IndexCartesian())
+                    for i ∈ eachindex(i_style, a)
+                        @test isassigned(a, i) == isbitstype(elem_type)
+                    end
+                end
+            end
+            @testset "some assigned" begin
+                a = FixedSizeMatrix{FixedSizeMatrix{Nothing}}(undef, 3, 3)
+                assigned_inds = ((1, 2), (2, 3), (3, 3))
+                for ij ∈ assigned_inds
+                    a[ij...] = FixedSizeMatrix{Nothing}(undef, 1, 1)
+                end
+                for ij ∈ Iterators.product(1:3, 1:3)
+                    @test isassigned(a, ij...) == (ij ∈ assigned_inds)
+                end
+            end
+        end
+    end
 end


### PR DESCRIPTION
Fixes #14

The below benchmark shows many orders of magnitude of performance improvement, more so for arrays with many `undef` elements:

```julia
using BenchmarkTools, FixedSizeArrays

function new_arr(len, prob)
  ret = FixedSizeVector{FixedSizeVector{Nothing}}(undef, len)
  for i ∈ eachindex(ret)
    if rand() < prob
      ret[i] = eltype(ret)(undef, 0)
    end
  end
  ret
end

function assigned_count(arr)
  cnt = 0
  for i ∈ eachindex(arr)
    cnt += isassigned(arr, i)
  end
  cnt
end

len = 10000

arr = new_arr(len, 0.1);
@btime assigned_count(arr)
# prior to this change: 244.170 ms
# with this change:     6.879 μs

arr = new_arr(len, 0.5);
@btime assigned_count(arr)
# prior to this change: 134.400 ms
# with this change:     6.871 μs

arr = new_arr(len, 0.9);
@btime assigned_count(arr)
# prior to this change: 27.091 ms
# with this change:     6.879 μs

versioninfo()
# Julia Version 1.12.0-DEV.379
# Commit aad72458539 (2024-04-20 23:40 UTC)
# Build Info:
#   Official https://julialang.org/ release
# Platform Info:
#   OS: Linux (x86_64-linux-gnu)
#   CPU: 8 × AMD Ryzen 3 5300U with Radeon Graphics
#   WORD_SIZE: 64
#   LLVM: libLLVM-16.0.6 (ORCJIT, znver2)
# Threads: 1 default, 0 interactive, 1 GC (on 8 virtual cores)
```