### PR TITLE
specialize `copyto!` for performance

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,4 +131,22 @@ import Aqua
             end
         end
     end
+
+    @testset "`copyto!`" begin
+        for (D, S) ∈ (
+            (Memory, FixedSizeVector),
+            (FixedSizeVector, Memory),
+            (FixedSizeVector, FixedSizeVector),
+        )
+            for E ∈ (Float64, Int)
+                s = S{E}(undef, 5)
+                s .= 1:5
+                d = D{Float64}(undef, 5)
+                @test copyto!(d, s) isa D{Float64}
+                @test copyto!(d, s) == 1:5
+                @test copyto!(d, 1, s, 1, length(s)) isa D{Float64}
+                @test copyto!(d, 1, s, 1, length(s)) == 1:5
+            end
+        end
+    end
 end


### PR DESCRIPTION
The fallback generic implementation of `copyto!` uses `setindex!` in an elementwise manner. Instead base the implementation on `unsafe_copyto!`. This improves the performance of `copyto!`, thus it also improves the performance of `copy!`, `copy` and of broadcasted operations.

This change only applies when copying between two `FixedSizeArray`s, or between a `Memory` and a `FixedSizeArray`.

Fixes #19