### PR TITLE
implement `Base.elsize` for the strided arrays interface

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -76,6 +76,8 @@ end
 
 # helper functions
 
+parent_type(::Type{<:FixedSizeArray{T}}) where {T} = Memory{T}
+
 memory_of(m::Memory) = m
 memory_of(f::FixedSizeArray) = f.mem
 
@@ -142,5 +144,9 @@ Base.@propagate_inbounds Base.copyto!(dst::Memory        , src::FixedSizeArray) 
 # unsafe: the native address of the array's storage
 
 Base.unsafe_convert(::Type{Ptr{T}}, a::FixedSizeArray{T}) where {T} = Base.unsafe_convert(Ptr{T}, a.mem)
+
+# `elsize`: part of the strided arrays interface, used for `pointer`
+
+Base.elsize(::Type{A}) where {A<:FixedSizeArray} = Base.elsize(parent_type(A))
 
 end # module FixedSizeArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,4 +237,18 @@ end
             @test M_mul ≈ M * M
         end
     end
+
+    @testset "`pointer`" begin
+        for elem_type ∈ (Int8, Int16, Int32, Int64)
+            for dim_count ∈ 0:4
+                siz = ntuple(Returns(2), dim_count)
+                arr = FixedSizeArray{elem_type, dim_count}(undef, siz)
+                @test pointer(arr) === pointer(arr, 1) === pointer(arr, 2) - sizeof(elem_type)
+                @test (@inferred pointer(arr))    isa Ptr{elem_type}
+                @test (@inferred pointer(arr, 1)) isa Ptr{elem_type}
+                @test iszero(allocated(pointer, arr))
+                @test iszero(allocated(pointer, arr, 1))
+            end
+        end
+    end
 end


### PR DESCRIPTION
Makes `pointer(::FixedSizeArray, ::Int)` work.

Fixes #25