### PR TITLE
support specifying dimensions with non-`Int` integers

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -23,13 +23,17 @@ const FixedSizeMatrix{T} = FixedSizeArray{T,2}
 function FixedSizeArray{T,N}(::UndefInitializer, size::NTuple{N,Int}) where {T,N}
     FixedSizeArray{T,N}(Internal(), Memory{T}(undef, checked_dims(size)), size)
 end
-function FixedSizeArray{T,N}(::UndefInitializer, size::Vararg{Int,N}) where {T,N}
+function FixedSizeArray{T,N}(::UndefInitializer, size::NTuple{N,Integer}) where {T,N}
+    ints = map(Int, size)::NTuple{N,Int}  # prevent infinite recursion
+    FixedSizeArray{T,N}(undef, ints)
+end
+function FixedSizeArray{T,N}(::UndefInitializer, size::Vararg{Integer,N}) where {T,N}
     FixedSizeArray{T,N}(undef, size)
 end
-function FixedSizeArray{T}(::UndefInitializer, size::Vararg{Int,N}) where {T,N}
+function FixedSizeArray{T}(::UndefInitializer, size::Vararg{Integer,N}) where {T,N}
     FixedSizeArray{T,N}(undef, size)
 end
-function FixedSizeArray{T}(::UndefInitializer, size::NTuple{N,Int}) where {T,N}
+function FixedSizeArray{T}(::UndefInitializer, size::NTuple{N,Integer}) where {T,N}
     FixedSizeArray{T,N}(undef, size)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,9 +47,11 @@ end
             siz = ntuple(Returns(2), dim_count)
             T = FixedSizeArray{Float64}
             R = FixedSizeArray{Float64,dim_count}
-            for args ∈ ((undef, siz), (undef, siz...))
-                test_inferred(   R, args)
-                test_inferred(T, R, args)
+            for sz ∈ (siz, map(BigInt, siz))
+                for args ∈ ((undef, sz), (undef, sz...))
+                    test_inferred(   R, args)
+                    test_inferred(T, R, args)
+                end
             end
         end
         for offset ∈ (-1, 0, 2, 3)


### PR DESCRIPTION
`Array` supports the same for their `undef` constructor (although `Memory` doesn't), so `FixedSizeArray` probably should, too.