### PR TITLE
introduce function `collect_as` for construction from an iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,46 @@ Main differences between `FixedSizeArray` and `MArray` are:
 * `FixedSizeArray` is based on the `Memory` type introduced in Julia v1.11, `MArray` is backed by tuples;
 * the size of the array is part of the type parameters of `MArray`, this isn't the case for `FixedSizeArray`, where the size is only a constant field of the data structure.
 
+FixedSizeArrays supports the usual array interfaces, so things like broadcasting, matrix
+multiplication, other linear algebra operations, `similar`, `copyto!` or `map` should just work.
+
+Use the constructors to convert from other array types. Use `collect_as` to convert from
+arbitrary iterators.
+
+```julia-repl
+julia> arr = [10 20; 30 14]
+2×2 Matrix{Int64}:
+ 10  20
+ 30  14
+
+julia> iter = (i for i ∈ 7:9 if i≠8);
+
+julia> using FixedSizeArrays
+
+julia> FixedSizeArray(arr)  # construct from an `AbstractArray` value
+2×2 FixedSizeMatrix{Int64}:
+ 10  20
+ 30  14
+
+julia> FixedSizeArray{Float64}(arr)  # construct from an `AbstractArray` value while converting element type
+2×2 FixedSizeMatrix{Float64}:
+ 10.0  20.0
+ 30.0  14.0
+
+julia> const ca = FixedSizeArrays.collect_as
+collect_as (generic function with 1 method)
+
+julia> ca(FixedSizeArray, iter)  # construct from an arbitrary iterator
+2-element FixedSizeVector{Int64}:
+ 7
+ 9
+
+julia> ca(FixedSizeArray{Float64}, iter)  # construct from an arbitrary iterator while converting element type
+2-element FixedSizeVector{Float64}:
+ 7.0
+ 9.0
+```
+
 Note: `FixedSizeArray`s are not guaranteed to be stack-allocated, in fact they will more likely *not* be stack-allocated.
 However, in some *extremely* simple cases the compiler may be able to completely elide their allocations:
 ```julia

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -110,7 +110,6 @@ function check_count_value(n::Int)
     if n < 0
         throw(ArgumentError("count can't be negative"))
     end
-    nothing
 end
 function check_count_value(n)
     throw(ArgumentError("count must be an `Int`"))
@@ -255,7 +254,6 @@ function fill_fsa_from_iterator!(a, iterator)
     if actual_count != length(a)
         throw(ArgumentError("`size`-`length` inconsistency"))
     end
-    nothing
 end
 
 function collect_as_fsam_with_shape(

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -335,11 +335,6 @@ function collect_as_fsa(iterator, spec::SpecFSA)
     collect_as_fsa_checked(iterator, spec, dim_count, len_stat)::R
 end
 
-function collect_as_fsa(a::AbstractArray, spec::SpecFSA)
-    R = fsa_spec_to_type(spec)::Type{<:FixedSizeArray}
-    R(a)::R
-end
-
 """
     collect_as(t::Type{<:FixedSizeArray}, iterator)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -370,7 +370,7 @@ end
         iterators = (
             (), (7,), (7, 8), 7, (7 => 8), Ref(7), fill(7),
             (i for i ∈ 1:3), ((i + 100*j) for i ∈ 1:3, j ∈ 1:2), Iterators.repeated(7, 2),
-            (i for i ∈ 7:9 if i==8), 7:8, 8:7, Int[], [7], [7 8],
+            (i for i ∈ 7:9 if i==8), 7:8, 8:7, map(BigInt, 7:8), Int[], [7], [7 8],
         )
         abstract_array_params(::AbstractArray{T,N}) where {T,N} = (T, N)
         @testset "iterator: $iterator" for iterator ∈ iterators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -388,9 +388,7 @@ end
         Base.size(i::Iter) = i.size
         Base.eltype(::Type{<:Iter{E}}) where {E} = E
         @testset "buggy iterator with mismatched `size` and `length" begin
-            for iterator ∈ (
-                Iter((), 0, 7), Iter((3, 2), 5, 7),
-            )
+            for iterator ∈ (Iter((), 0, 7), Iter((3, 2), 5, 7))
                 E = eltype(iterator)
                 dim_count = length(size(iterator))
                 for T ∈ (FixedSizeArray, FixedSizeArray{E}, FixedSizeArray{<:Any,dim_count}, FixedSizeArray{E,dim_count})


### PR DESCRIPTION
Makes constructing `FixedSizeArray`s more convenient!

Inspired by
https://github.com/JuliaLang/julia/issues/36288

This currently ignores `Base.IteratorElType`, xref https://discourse.julialang.org/t/i-dont-get-base-iteratoreltype/113604

The allocations in some code paths are probably excessive/could be optimized. But I guess this is good for a start.

Fixes #20