### PR TITLE
specialize `cconvert` instead of `unsafe_convert`

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -189,7 +189,7 @@ end
 
 # unsafe: the native address of the array's storage
 
-Base.unsafe_convert(::Type{Ptr{T}}, a::FixedSizeArray{T}) where {T} = Base.unsafe_convert(Ptr{T}, a.mem)
+Base.cconvert(::Type{<:Ptr}, a::FixedSizeArray) = a.mem
 
 # `elsize`: part of the strided arrays interface, used for `pointer`
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/issues/51962#issuecomment-1787811957

> It is generally best to implement cconvert (since it is not unsafe),
> and generally required to call both functions as well (mimicking the
> behavior defined for ccall)