### PR TITLE
support `GenericMemory` by making the storage type a parameter

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -29,9 +29,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-
+        build_is_production_build:
+          - true
     runs-on: ${{ matrix.os }}
-
     steps:
     - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@v2
@@ -40,6 +40,33 @@ jobs:
         version: ${{ matrix.julia_version }}
     - uses: julia-actions/cache@v2
     - uses: julia-actions/julia-runtest@v1
+      env:
+        BUILD_IS_PRODUCTION_BUILD: ${{ matrix.build_is_production_build }}
+      with:
+        coverage: false
+  test-with-code-coverage:
+    name: Julia ${{ matrix.julia_version }} - ${{ matrix.os }} - ${{ matrix.julia_arch }} - with code coverage
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        julia_version:
+          - "~1.11.0-0"
+        julia_arch:
+          - x64
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: julia-actions/setup-julia@v2
+      with:
+        arch: ${{ matrix.julia_arch }}
+        version: ${{ matrix.julia_version }}
+    - uses: julia-actions/cache@v2
+    - uses: julia-actions/julia-runtest@v1
+      env:
+        BUILD_IS_PRODUCTION_BUILD: false
     - uses: julia-actions/julia-processcoverage@v1
     - uses: codecov/codecov-action@v4
       with:

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -22,7 +22,7 @@ end
 const FixedSizeVector{T} = FixedSizeArray{T,1}
 const FixedSizeMatrix{T} = FixedSizeArray{T,2}
 
-const default_underlying_storage_type = Memory  # TODO: make user-configurable via Preferences.jl?
+const default_underlying_storage_type = Memory
 
 function FixedSizeArray{T,N,V}(::UndefInitializer, size::NTuple{N,Int}) where {T,N,V}
     FixedSizeArray{T,N,V}(Internal(), V(undef, checked_dims(size))::V, size)

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -11,23 +11,37 @@ Implementation detail. Do not use.
 """
 struct Internal end
 
-struct FixedSizeArray{T,N} <: DenseArray{T,N}
-    mem::Memory{T}
+struct FixedSizeArray{T,N,Mem<:GenericMemory{<:Any,T}} <: DenseArray{T,N}
+    mem::Mem
     size::NTuple{N,Int}
-    function FixedSizeArray{T,N}(::Internal, mem::Memory{T}, size::NTuple{N,Int}) where {T,N}
-        new{T,N}(mem, size)
+    function FixedSizeArray{T,N,M}(::Internal, mem::M, size::NTuple{N,Int}) where {T,N,M<:GenericMemory{<:Any,T}}
+        new{T,N,M}(mem, size)
     end
 end
 
 const FixedSizeVector{T} = FixedSizeArray{T,1}
 const FixedSizeMatrix{T} = FixedSizeArray{T,2}
 
-function FixedSizeArray{T,N}(::UndefInitializer, size::NTuple{N,Int}) where {T,N}
-    FixedSizeArray{T,N}(Internal(), Memory{T}(undef, checked_dims(size)), size)
+const default_underlying_storage_type = Memory  # TODO: make user-configurable via Preferences.jl?
+
+function FixedSizeArray{T,N,V}(::UndefInitializer, size::NTuple{N,Int}) where {T,N,V}
+    FixedSizeArray{T,N,V}(Internal(), V(undef, checked_dims(size))::V, size)
+end
+function FixedSizeArray{T,N,V}(::UndefInitializer, size::NTuple{N,Integer}) where {T,N,V}
+    ints = map(Int, size)::NTuple{N,Int}  # prevent infinite recursion
+    FixedSizeArray{T,N,V}(undef, ints)
+end
+function FixedSizeArray{T,N,V}(::UndefInitializer, size::Vararg{Integer,N}) where {T,N,V}
+    FixedSizeArray{T,N,V}(undef, size)
+end
+function FixedSizeArray{T,<:Any,V}(::UndefInitializer, size::NTuple{N,Integer}) where {T,N,V}
+    FixedSizeArray{T,N,V}(undef, size)
+end
+function FixedSizeArray{T,<:Any,V}(::UndefInitializer, size::Vararg{Integer,N}) where {T,N,V}
+    FixedSizeArray{T,N,V}(undef, size)
 end
 function FixedSizeArray{T,N}(::UndefInitializer, size::NTuple{N,Integer}) where {T,N}
-    ints = map(Int, size)::NTuple{N,Int}  # prevent infinite recursion
-    FixedSizeArray{T,N}(undef, ints)
+    FixedSizeArray{T,N,default_underlying_storage_type{T}}(undef, size)
 end
 function FixedSizeArray{T,N}(::UndefInitializer, size::Vararg{Integer,N}) where {T,N}
     FixedSizeArray{T,N}(undef, size)
@@ -45,8 +59,8 @@ Base.@propagate_inbounds Base.setindex!(A::FixedSizeArray, v, i::Int) = A.mem[i]
 
 Base.size(a::FixedSizeArray) = a.size
 
-function Base.similar(::FixedSizeArray, ::Type{S}, size::NTuple{N,Int}) where {S,N}
-    FixedSizeArray{S,N}(undef, size)
+function Base.similar(::T, ::Type{E}, size::NTuple{N,Int}) where {T<:FixedSizeArray,E,N}
+    with_replaced_parameters(DenseArray, T, Val(E), Val(N))(undef, size)
 end
 
 Base.isassigned(a::FixedSizeArray, i::Int) = isassigned(a.mem, i)
@@ -83,18 +97,44 @@ end
 
 # broadcasting
 
-function Base.BroadcastStyle(::Type{<:FixedSizeArray})
-    Broadcast.ArrayStyle{FixedSizeArray}()
+function Base.BroadcastStyle(::Type{T}) where {T<:FixedSizeArray}
+    Broadcast.ArrayStyle{stripped_type(DenseArray, T)}()
 end
 
 function Base.similar(
-    bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{FixedSizeArray}},
+    bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{S}},
     ::Type{E},
-) where {E}
-    similar(FixedSizeArray{E}, axes(bc))
+) where {S<:FixedSizeArray,E}
+    similar(S{E}, axes(bc))
 end
 
 # helper functions
+
+normalized_type(::Type{T}) where {T} = T
+
+function stripped_type_unchecked(::Type{DenseVector}, ::Type{<:GenericMemory{K,<:Any,AS}}) where {K,AS}
+    GenericMemory{K,<:Any,AS}
+end
+
+Base.@assume_effects :consistent function stripped_type_unchecked(
+    ::Type{DenseArray}, ::Type{<:FixedSizeArray{<:Any,<:Any,V}},
+) where {V}
+    U = stripped_type(DenseVector, V)
+    FixedSizeArray{E,N,U{E}} where {E,N}
+end
+
+function stripped_type(::Type{T}, ::Type{S}) where {T,S<:T}
+    ret = stripped_type_unchecked(T, S)::Type{<:T}::UnionAll
+    S::Type{<:ret}
+    normalized_type(ret)  # ensure `UnionAll` type variable order is normalized
+end
+
+function with_replaced_parameters(::Type{T}, ::Type{S}, ::Val{P1}, ::Val{P2}) where {T,S<:T,P1,P2}
+    t = T{P1,P2}::Type{<:T}
+    s = stripped_type(T, S)
+    S::Type{<:s}
+    s{P1,P2}::Type{<:s}::Type{<:T}::Type{<:t}
+end
 
 dimension_count_of(::Base.SizeUnknown) = 1
 dimension_count_of(::Base.HasLength) = 1
@@ -115,23 +155,49 @@ function check_count_value(n)
     throw(ArgumentError("count must be an `Int`"))
 end
 
-struct SpecFSA{T,N} end
+# TODO: use `SpecFSA` for implementing each `FixedSizeArray` constructor?
+struct SpecFSA{N,Mem<:GenericMemory} end
 function fsa_spec_from_type(::Type{FixedSizeArray})
-    SpecFSA{nothing,nothing}()
+    SpecFSA{nothing,default_underlying_storage_type}()
 end
 function fsa_spec_from_type(::Type{FixedSizeArray{<:Any,M}}) where {M}
     check_count_value(M)
-    SpecFSA{nothing,M}()
+    SpecFSA{M,default_underlying_storage_type}()
 end
 function fsa_spec_from_type(::Type{FixedSizeArray{E}}) where {E}
-    SpecFSA{E::Type,nothing}()
+    E::Type
+    SpecFSA{nothing,default_underlying_storage_type{E}}()
 end
 function fsa_spec_from_type(::Type{FixedSizeArray{E,M}}) where {E,M}
     check_count_value(M)
-    SpecFSA{E::Type,M}()
+    E::Type
+    SpecFSA{M,default_underlying_storage_type{E}}()
+end
+function fsa_spec_from_type(::Type{FixedSizeArray{E,<:Any,V}}) where {E,V}
+    E::Type
+    V::Type{<:DenseVector{E}}
+    SpecFSA{nothing,V}()
+end
+function fsa_spec_from_type(::Type{FixedSizeArray{E,M,V}}) where {E,M,V}
+    check_count_value(M)
+    E::Type
+    V::Type{<:DenseVector{E}}
+    SpecFSA{M,V}()
+end
+for V ∈ (Memory, AtomicMemory)
+    T = FixedSizeArray{E,M,V{E}} where {E,M}
+    @eval begin
+        function fsa_spec_from_type(::Type{$T})
+            SpecFSA{nothing,$V}()
+        end
+        function fsa_spec_from_type(::Type{($T){<:Any,M}}) where {M}
+            check_count_value(M)
+            SpecFSA{M,$V}()
+        end
+    end
 end
 
-parent_type(::Type{<:FixedSizeArray{T}}) where {T} = Memory{T}
+parent_type(::Type{<:FixedSizeArray{<:Any,<:Any,T}}) where {T} = T
 
 underlying_storage(m) = m
 underlying_storage(f::FixedSizeArray) = f.mem
@@ -140,7 +206,7 @@ axes_are_one_based(axes) = all(isone ∘ first, axes)
 
 # converting constructors for copying other array types
 
-function FixedSizeArray{T,N}(src::AbstractArray{S,N}) where {T,N,S}
+function FixedSizeArray{T,N,V}(src::AbstractArray{S,N}) where {T,N,V,S}
     axs = axes(src)
     if !axes_are_one_based(axs)
         throw(DimensionMismatch("source array has a non-one-based indexing axis"))
@@ -148,11 +214,14 @@ function FixedSizeArray{T,N}(src::AbstractArray{S,N}) where {T,N,S}
     # Can't use `Base.size` because, according to it's doc string, it's not
     # available for all `AbstractArray` types.
     size = map(length, axs)
-    dst = FixedSizeArray{T,N}(undef, size)
+    dst = FixedSizeArray{T,N,V}(undef, size)
     copyto!(dst.mem, src)
     dst
 end
 
+FixedSizeArray{T,<:Any,V}(a::AbstractArray{<:Any,N}) where {V,T,N} = FixedSizeArray{T,N,V}(a)
+
+FixedSizeArray{T,N}(a::AbstractArray{<:Any,N}) where {T,N} = FixedSizeArray{T,N,default_underlying_storage_type{T}}(a)
 FixedSizeArray{T}(a::AbstractArray{<:Any,N})   where {T,N} = FixedSizeArray{T,N}(a)
 FixedSizeArray{<:Any,N}(a::AbstractArray{T,N}) where {T,N} = FixedSizeArray{T,N}(a)
 FixedSizeArray(a::AbstractArray{T,N})          where {T,N} = FixedSizeArray{T,N}(a)
@@ -197,27 +266,29 @@ Base.elsize(::Type{A}) where {A<:FixedSizeArray} = Base.elsize(parent_type(A))
 
 # `reshape`: specializing it to ensure it returns a `FixedSizeArray`
 
-function Base.reshape(a::FixedSizeArray{T}, size::NTuple{N,Int}) where {T,N}
+function Base.reshape(a::FixedSizeArray{T,<:Any,V}, size::NTuple{N,Int}) where {V,T,N}
     len = checked_dims(size)
     if length(a) != len
         throw(DimensionMismatch("new shape not consistent with existing array length"))
     end
-    FixedSizeArray{T,N}(Internal(), a.mem, size)
+    FixedSizeArray{T,N,V}(Internal(), a.mem, size)
 end
 
 # `collect_as`
 
-function collect_as_fsa0(iterator, ::Val{nothing})
+function collect_as_fsa0(iterator, ::SpecFSA{0,V}) where {V}
+    V::UnionAll
     x = only(iterator)
-    ret = FixedSizeArray{typeof(x),0}(undef)
+    E = typeof(x)::Type
+    ret = FixedSizeArray{E,0,V{E}}(undef)
     ret[] = x
     ret
 end
 
-function collect_as_fsa0(iterator, ::Val{E}) where {E}
+function collect_as_fsa0(iterator, ::SpecFSA{0,V}) where {E,V<:DenseVector{E}}
     E::Type
     x = only(iterator)
-    ret = FixedSizeArray{E,0}(undef)
+    ret = FixedSizeArray{E,0,V}(undef)
     ret[] = x
     ret
 end
@@ -234,24 +305,26 @@ function fill_fsa_from_iterator!(a, iterator)
 end
 
 function collect_as_fsam_with_shape(
-    iterator, ::SpecFSA{nothing,M}, shape::Tuple{Vararg{Int}},
-) where {M}
+    iterator, ::SpecFSA{M,V}, shape::Tuple{Vararg{Int}},
+) where {M,V}
+    V::UnionAll
     E = eltype(iterator)::Type
-    ret = FixedSizeArray{E,M}(undef, shape)
+    U = V{E}
+    ret = FixedSizeArray{E,M,U}(undef, shape)
     fill_fsa_from_iterator!(ret, iterator)
-    map(identity, ret)::FixedSizeArray{<:Any,M}
+    map(identity, ret)::(FixedSizeArray{T,M,V{T}} where {T})
 end
 
 function collect_as_fsam_with_shape(
-    iterator, ::SpecFSA{E,M}, shape::Tuple{Vararg{Int}},
-) where {E,M}
+    iterator, ::SpecFSA{M,V}, shape::Tuple{Vararg{Int}},
+) where {M,E,V<:DenseVector{E}}
     E::Type
-    ret = FixedSizeArray{E,M}(undef, shape)
+    ret = FixedSizeArray{E,M,V}(undef, shape)
     fill_fsa_from_iterator!(ret, iterator)
-    ret::FixedSizeArray{E,M}
+    ret::FixedSizeArray{E,M,V}
 end
 
-function collect_as_fsam(iterator, spec::SpecFSA{<:Any,M}) where {M}
+function collect_as_fsam(iterator, spec::SpecFSA{M}) where {M}
     check_count_value(M)
     shape = if isone(M)
         (length(iterator),)
@@ -262,39 +335,42 @@ function collect_as_fsam(iterator, spec::SpecFSA{<:Any,M}) where {M}
     collect_as_fsam_with_shape(iterator, spec, shap)::FixedSizeArray{<:Any,M}
 end
 
-function collect_as_fsa1_from_unknown_length(iterator, ::Val{nothing})
+function collect_as_fsa1_from_unknown_length(iterator, ::SpecFSA{1,V}) where {V}
+    V::UnionAll
     v = collect(iterator)::AbstractVector
-    T = FixedSizeVector
-    map(identity, T(v))::T
+    t = FixedSizeVector(v)::FixedSizeVector
+    s = map(identity, t)::FixedSizeVector  # fix element type
+    et = eltype(s)
+    FixedSizeVector{et,V{et}}(s)  # fix underlying storage type
 end
 
-function collect_as_fsa1_from_unknown_length(iterator, ::Val{E}) where {E}
+function collect_as_fsa1_from_unknown_length(iterator, ::SpecFSA{1,V}) where {E,V<:DenseVector{E}}
     E::Type
     v = collect(E, iterator)::AbstractVector{E}
-    T = FixedSizeVector{E}
+    T = FixedSizeVector{E,V}
     T(v)::T
 end
 
-function collect_as_fsa_impl(iterator, ::SpecFSA{E,0}, ::LengthIsKnown) where {E}
-    collect_as_fsa0(iterator, Val(E))::FixedSizeArray{<:Any,0}
+function collect_as_fsa_impl(iterator, spec::SpecFSA{0}, ::LengthIsKnown)
+    collect_as_fsa0(iterator, spec)::FixedSizeArray{<:Any,0}
 end
 
 function collect_as_fsa_impl(iterator, spec::SpecFSA, ::LengthIsKnown)
     collect_as_fsam(iterator, spec)::FixedSizeArray
 end
 
-function collect_as_fsa_impl(iterator, ::SpecFSA{E,1}, ::LengthIsUnknown) where {E}
-    collect_as_fsa1_from_unknown_length(iterator, Val(E))::FixedSizeVector
+function collect_as_fsa_impl(iterator, spec::SpecFSA{1}, ::LengthIsUnknown)
+    collect_as_fsa1_from_unknown_length(iterator, spec)::FixedSizeVector
 end
 
-function collect_as_fsa_checked(iterator, ::SpecFSA{E,nothing}, ::Val{M}, length_status) where {E,M}
+function collect_as_fsa_checked(iterator, ::SpecFSA{nothing,V}, ::Val{M}, length_status) where {V,M}
     check_count_value(M)
-    collect_as_fsa_impl(iterator, SpecFSA{E,M}(), length_status)::FixedSizeArray{<:Any,M}
+    collect_as_fsa_impl(iterator, SpecFSA{M,V}(), length_status)::FixedSizeArray{<:Any,M}
 end
 
-function collect_as_fsa_checked(iterator, ::SpecFSA{E,M}, ::Val{M}, length_status) where {E,M}
+function collect_as_fsa_checked(iterator, spec::SpecFSA{M}, ::Val{M}, length_status) where {M}
     check_count_value(M)
-    collect_as_fsa_impl(iterator, SpecFSA{E,M}(), length_status)::FixedSizeArray{<:Any,M}
+    collect_as_fsa_impl(iterator, spec, length_status)::FixedSizeArray{<:Any,M}
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,382 +69,383 @@ end
     end
 
     storage_types = (Memory, Vector, fsv(Memory), fsv(Vector), fsv(fsv(Memory)))
-    storage_type = first(storage_types)
-    FSV = fsv(storage_type)
-    FSM = fsm(storage_type)
-    FSA = fsa(storage_type)
+    for storage_type ∈ storage_types
+        FSV = fsv(storage_type)
+        FSM = fsm(storage_type)
+        FSA = fsa(storage_type)
 
-    @testset "Constructors" begin
-        for dim_count ∈ 0:4
-            siz = ntuple(Returns(2), dim_count)
-            T = FSA{Float64}
-            R = FSA{Float64,dim_count}
-            for sz ∈ (siz, map(BigInt, siz))
-                for args ∈ ((undef, sz), (undef, sz...))
-                    test_inferred(   R, args)
-                    test_inferred(T, R, args)
-                end
-            end
-        end
-        for offset ∈ (-1, 0, 2, 3)
-            ax = offset:(offset + 1)
-            oa = OffsetArray([10, 20], ax)
-            @test_throws DimensionMismatch FSA(oa)
-            @test_throws DimensionMismatch FSV(oa)
-            @test_throws DimensionMismatch FSA{Int}(oa)
-            @test_throws DimensionMismatch FSV{Int}(oa)
-        end
-        @testset "taken from Julia's test/core.jl" begin
-            # inspired by:
-            # https://github.com/JuliaLang/julia/blob/83929ad883c97fa4376618c4559b74f6ada7a3ce/test/core.jl#L7211-L7228
-            b = prevpow(2, typemax(Int))
-            test_inferred(FSA{Int}, FSA{Int,3}, (undef, 0, b, b))
-            test_inferred(FSA{Int}, FSA{Int,3}, (undef, b, b, 0))
-            test_inferred(FSA{Int}, FSA{Int,5}, (undef, b, b, 0, b, b))
-            @test_throws ArgumentError FSA{Int}(undef, b, b)
-            @test_throws ArgumentError FSA{Int}(undef, 1, b, b)
-            @test_throws ArgumentError FSA{Int}(undef, 0, -10)
-            @test_throws ArgumentError FSA{Int}(undef, -10, 0)
-            @test_throws ArgumentError FSA{Int}(undef, -1, -1)
-            @test_throws ArgumentError FSA{Int}(undef, 0, -4, -4)
-            @test_throws ArgumentError FSA{Int}(undef, -4, 1, 0)
-            @test_throws ArgumentError FSA{Int}(undef, -4, -4, 1)
-        end
-        @test_throws ArgumentError FSA{Float64,1}(undef, -1)
-        @test_throws ArgumentError FSA{Float64,1}(undef, (-1,))
-        @test_throws ArgumentError FSA{Float64,2}(undef, -1, -1)
-        @test_throws ArgumentError FSA{Float64,2}(undef, typemax(Int), 0)
-        @test_throws ArgumentError FSA{Float64,2}(undef, typemax(Int), typemax(Int))
-        @test_throws ArgumentError FSA{Float64,3}(undef, typemax(Int)-1, typemax(Int)-1, 2)
-        @test_throws ArgumentError FSA{Float64,4}(undef, typemax(Int)-1, typemax(Int)-1, 2, 4)
-        @testset "negative dimension size" begin
-            for n ∈ 2:4
-                funs = (
-                    Returns(-1),
-                    (i -> (i == 1) ?  1 : -1),
-                    (i -> (i == 1) ? -1 :  1),
-                    (i -> (i == n) ?  1 : -1),
-                    (i -> (i == n) ? -1 :  1),
-                )
-                fun = f -> ntuple(f, n)
-                sizes = map(fun, funs)
-                for siz ∈ sizes
-                    @test_throws ArgumentError FSA{Float64,n}(undef, siz)
-                    @test_throws ArgumentError FSA{Float64,n}(undef, siz...)
-                end
-            end
-        end
-    end
-
-    @testset "FixedSizeVector" begin
-        v = FSV{Float64}(undef, 3)
-        @test length(v) == 3
-        test_inferred_noalloc(((a, b) -> a .= b), FSV{Float64}, (v, 1:3))
-        @test v == 1:3
-        test_inferred(similar, FSV{Float64}, (v,))
-        test_inferred(similar, FSV{Int}, (v, Int))
-        test_inferred(copy, FSV{Float64}, (v,))
-        test_inferred(zero, FSV{Float64}, (v,))
-        test_inferred(similar, FSV{Int}, (FSV{Int}, (2,)))
-        test_inferred(similar, FSV{Int}, (FSA{Int}, (2,)))
-        example_abstract_vectors = (7:9, [7, 8, 9], OffsetArray([7, 8, 9], 1:3))
-        test_convert = function(T, a)
-            test_inferred(convert, FSV{Int}, (T, a))
-            c = convert(T, a)
-            test_inferred(convert, FSV{Int}, (T, c))
-            @test c == a
-            @test c === convert(T, c)
-        end
-        for T ∈ (FSA, FSV)
-            for a ∈ example_abstract_vectors
-                test_convert(T, a)
-            end
-        end
-        for T ∈ (FSA{Int}, FSV{Int})
-            for S ∈ (Int, Float64)
-                for a ∈ map((c -> map(S, c)), example_abstract_vectors)
-                    test_convert(T, a)
-                end
-            end
-        end
-    end
-
-    @testset "FixedSizeMatrix" begin
-        m = FSM{Float64}(undef, 3, 3)
-        m_ref = reshape(1:9, size(m))
-        @test length(m) == 9
-        test_inferred_noalloc(((a, b) -> a .= b), FSM{Float64}, (m, m_ref))
-        @test m == m_ref
-        test_inferred(similar, FSM{Float64}, (m,))
-        test_inferred(similar, FSM{Int}, (m, Int))
-        test_inferred(copy, FSM{Float64}, (m,))
-        test_inferred(zero, FSM{Float64}, (m,))
-        test_inferred(similar, FSM{Int}, (FSM{Int}, (2, 3)))
-        test_inferred(similar, FSM{Int}, (FSA{Int}, (2, 3)))
-        example_abstract_matrices = (
-            reshape(1:9, (3, 3)),
-            OffsetArray(reshape(1:9, (3, 3)), 1:3, 1:3),
-        )
-        test_convert = function(T, a)
-            test_inferred(convert, FSM{Int}, (T, a))
-            c = convert(T, a)
-            test_inferred(convert, FSM{Int}, (T, c))
-            @test c == a
-            @test c === convert(T, c)
-        end
-        for T ∈ (FSA, FSM)
-            for a ∈ example_abstract_matrices
-                test_convert(T, a)
-            end
-        end
-        for T ∈ (FSA{Int}, FSM{Int})
-            for S ∈ (Int, Float64)
-                for a ∈ map((c -> map(S, c)), example_abstract_matrices)
-                    test_convert(T, a)
-                end
-            end
-        end
-    end
-
-    @testset "`map`" begin
-        for dim_count ∈ 0:3
-            size = ntuple(Returns(3), dim_count)
-            a = FSA{Int, dim_count}(undef, size)
-            for v ∈ (3, 3.1, nothing)
-                args = (Returns(v), a)
-                @test all(==(v), map(args...))
-                test_inferred(map, FSA{typeof(v), dim_count}, args)
-            end
-        end
-    end
-
-    @testset "broadcasting" begin
-        TVI = FSV{Int}
-        TVF = FSV{Float64}
-        v3 = TVI(1:3)
-        vf3 = TVF(1:3)
-        bp = (x, y) -> x .+ y
-        bm = (x, y) -> x .* y
-        test_inferred(+,  TVI, (v3, v3))
-        test_inferred(bp, TVI, (v3, v3))
-        test_inferred(bm, TVI, (v3, v3))
-        test_inferred(+,  TVF, (v3, vf3))
-        test_inferred(bp, TVF, (v3, vf3))
-        test_inferred(bm, TVF, (v3, vf3))
-        test_inferred(bp, TVI, (v3,  3))
-        test_inferred(bm, TVI, (v3,  3))
-        test_inferred(bp, TVF, (v3, .3))
-        test_inferred(bm, TVF, (v3, .3))
-        @testset "matrices" begin
-            TMI = FSM{Int}
-            TMF = FSM{Float64}
-            m33 = TMI(undef, 3, 3)
-            m13 = TMI(undef, 1, 3)
-            m31 = TMI(undef, 3, 1)
-            test_inferred(+,  TMI, (m33, m33))
-            test_inferred(bp, TMI, (m33, m33))
-            test_inferred(bm, TMI, (m33, m33))
-            test_inferred(bp, TMI, (m33, m13))
-            test_inferred(bm, TMI, (m33, m13))
-            test_inferred(bp, TMI, (m33, m31))
-            test_inferred(bm, TMI, (m33, m31))
-            test_inferred(bp, TMI, (m33, v3 ))
-            test_inferred(bm, TMI, (m33, v3 ))
-            test_inferred(bp, TMF, (m33, vf3))
-            test_inferred(bm, TMF, (m33, vf3))
-            test_inferred(bp, TMI, (m33,   3))
-            test_inferred(bm, TMI, (m33,   3))
-            test_inferred(bp, TMF, (m33,  .3))
-            test_inferred(bm, TMF, (m33,  .3))
-        end
-    end
-
-    @testset "`isassigned`" begin
-        for dim_count ∈ 0:3
-            for elem_type ∈ (Int, FSM{Nothing})
-                size = ntuple(Returns(3), dim_count)
-                a = FSA{elem_type, dim_count}(undef, size)
-                for i_style ∈ (IndexLinear(), IndexCartesian())
-                    for i ∈ eachindex(i_style, a)
-                        @test isassigned(a, i) == isbitstype(elem_type)
-                        test_inferred_noalloc(isassigned, Bool, (a, i))
-                    end
-                end
-            end
-        end
-        @testset "some assigned" begin
-            a = FSM{FSM{Nothing}}(undef, 3, 3)
-            assigned_inds = ((1, 2), (2, 3), (3, 3))
-            for ij ∈ assigned_inds
-                a[ij...] = FSM{Nothing}(undef, 1, 1)
-            end
-            for ij ∈ Iterators.product(1:3, 1:3)
-                @test isassigned(a, ij...) == (ij ∈ assigned_inds)
-                test_inferred_noalloc(isassigned, Bool, (a, ij...))
-            end
-        end
-    end
-
-    @testset "`copyto!`" begin
-        for (D, S) ∈ (
-            (Vector, FSV),
-            (Memory, FSV),
-            (FSV, Vector),
-            (FSV, Memory),
-            (FSV, FSV),
-        )
-            for E ∈ (Float64, Int)
-                s = S{E}(undef, 5)
-                s .= 1:5
-                d = D{Float64}(undef, 5)
-                test_inferred_noalloc(copyto!, D{Float64}, (d, s))
-                @test copyto!(d, s) == 1:5
-                args = (d, 1, s, 1, length(s))
-                test_inferred_noalloc(copyto!, D{Float64}, args)
-                @test copyto!(args...) == 1:5
-                @test_throws ArgumentError copyto!(d, 1, s, 1, -1)
-            end
-        end
-    end
-
-    @testset "LinearAlgebra" begin
-        @testset "$T" for T in (Float16, Float32, Float64)
-            v = randn(T, 8)
-            v_fixed = FSV(v)
-            test_inferred(+, FSV{T}, (v_fixed, v_fixed))
-            v_sum = v_fixed + v_fixed
-            @test v_sum ≈ v + v
-            test_inferred(((x, y) -> x * y'), FSM{T}, (v_fixed, v_fixed))
-            v_mul = v_fixed * v_fixed'
-            @test v_mul ≈ v * v'
-
-            M = randn(T, 8, 8)
-            M_fixed = FSM(M)
-            test_inferred(+, FSM{T}, (M_fixed, M_fixed))
-            M_sum = M_fixed + M_fixed
-            @test M_sum ≈ M + M
-            test_inferred(*, FSM{T}, (M_fixed, M_fixed))
-            M_mul = M_fixed * M_fixed
-            @test M_mul ≈ M * M
-        end
-    end
-
-    @testset "`pointer`" begin
-        for elem_type ∈ (Int8, Int16, Int32, Int64)
+        @testset "Constructors" begin
             for dim_count ∈ 0:4
                 siz = ntuple(Returns(2), dim_count)
-                arr = FSA{elem_type, dim_count}(undef, siz)
-                @test pointer(arr) === pointer(arr, 1) === pointer(arr, 2) - sizeof(elem_type)
-                test_inferred_noalloc(pointer, Ptr{elem_type}, (arr,))
-                test_inferred_noalloc(pointer, Ptr{elem_type}, (arr, 1))
+                T = FSA{Float64}
+                R = FSA{Float64,dim_count}
+                for sz ∈ (siz, map(BigInt, siz))
+                    for args ∈ ((undef, sz), (undef, sz...))
+                        test_inferred(   R, args)
+                        test_inferred(T, R, args)
+                    end
+                end
             end
-        end
-    end
-
-    @testset "`reshape`" begin
-        length_to_shapes = Dict(
-            (0 => ((0,), (0, 0), (0, 1), (1, 0), (1, 0, 0), (0, 0, 1))),
-            (1 => ((), (1,), (1, 1), (1, 1, 1))),
-            (2 => ((2,), (1, 2), (2, 1), (1, 2, 1))),
-            (3 => ((3,), (1, 3), (3, 1), (1, 3, 1))),
-            (4 => ((4,), (1, 4), (4, 1), (2, 2), (1, 2, 2), (2, 1, 2))),
-            (6 => ((6,), (1, 6), (6, 1), (2, 3), (3, 2), (1, 3, 2), (2, 1, 3))),
-        )
-        for elem_type ∈ (Int, Number, Union{Nothing,Int})
-            for len ∈ keys(length_to_shapes)
-                shapes = length_to_shapes[len]
-                for shape1 ∈ shapes
-                    a = FSA{elem_type,length(shape1)}(undef, shape1)
-                    @test_throws DimensionMismatch reshape(a, length(a)+1)
-                    @test_throws DimensionMismatch reshape(a, length(a)+1, 1)
-                    @test_throws DimensionMismatch reshape(a, 1, length(a)+1)
-                    for shape2 ∈ shapes
-                        @test prod(shape1) === prod(shape2) === len  # meta
-                        T = FSA{elem_type,length(shape2)}
-                        test_inferred_noalloc(reshape, T, (a, shape2))
-                        test_inferred_noalloc(reshape, T, (a, shape2...))
-                        b = reshape(a, shape2)
-                        @test size(b) === shape2
-                        @test a.mem === b.mem
-                        @test a === reshape(b, shape1)
+            for offset ∈ (-1, 0, 2, 3)
+                ax = offset:(offset + 1)
+                oa = OffsetArray([10, 20], ax)
+                @test_throws DimensionMismatch FSA(oa)
+                @test_throws DimensionMismatch FSV(oa)
+                @test_throws DimensionMismatch FSA{Int}(oa)
+                @test_throws DimensionMismatch FSV{Int}(oa)
+            end
+            @testset "taken from Julia's test/core.jl" begin
+                # inspired by:
+                # https://github.com/JuliaLang/julia/blob/83929ad883c97fa4376618c4559b74f6ada7a3ce/test/core.jl#L7211-L7228
+                b = prevpow(2, typemax(Int))
+                test_inferred(FSA{Int}, FSA{Int,3}, (undef, 0, b, b))
+                test_inferred(FSA{Int}, FSA{Int,3}, (undef, b, b, 0))
+                test_inferred(FSA{Int}, FSA{Int,5}, (undef, b, b, 0, b, b))
+                @test_throws ArgumentError FSA{Int}(undef, b, b)
+                @test_throws ArgumentError FSA{Int}(undef, 1, b, b)
+                @test_throws ArgumentError FSA{Int}(undef, 0, -10)
+                @test_throws ArgumentError FSA{Int}(undef, -10, 0)
+                @test_throws ArgumentError FSA{Int}(undef, -1, -1)
+                @test_throws ArgumentError FSA{Int}(undef, 0, -4, -4)
+                @test_throws ArgumentError FSA{Int}(undef, -4, 1, 0)
+                @test_throws ArgumentError FSA{Int}(undef, -4, -4, 1)
+            end
+            @test_throws ArgumentError FSA{Float64,1}(undef, -1)
+            @test_throws ArgumentError FSA{Float64,1}(undef, (-1,))
+            @test_throws ArgumentError FSA{Float64,2}(undef, -1, -1)
+            @test_throws ArgumentError FSA{Float64,2}(undef, typemax(Int), 0)
+            @test_throws ArgumentError FSA{Float64,2}(undef, typemax(Int), typemax(Int))
+            @test_throws ArgumentError FSA{Float64,3}(undef, typemax(Int)-1, typemax(Int)-1, 2)
+            @test_throws ArgumentError FSA{Float64,4}(undef, typemax(Int)-1, typemax(Int)-1, 2, 4)
+            @testset "negative dimension size" begin
+                for n ∈ 2:4
+                    funs = (
+                        Returns(-1),
+                        (i -> (i == 1) ?  1 : -1),
+                        (i -> (i == 1) ? -1 :  1),
+                        (i -> (i == n) ?  1 : -1),
+                        (i -> (i == n) ? -1 :  1),
+                    )
+                    fun = f -> ntuple(f, n)
+                    sizes = map(fun, funs)
+                    for siz ∈ sizes
+                        @test_throws ArgumentError FSA{Float64,n}(undef, siz)
+                        @test_throws ArgumentError FSA{Float64,n}(undef, siz...)
                     end
                 end
             end
         end
-    end
 
-    @testset "`collect_as`" begin
-        for T ∈ (FSA, FSV, FSA{Int}, FSV{Int})
-            for iterator ∈ (Iterators.repeated(7), Iterators.cycle(7))
-                @test_throws ArgumentError collect_as(T, iterator)
+        @testset "FixedSizeVector" begin
+            v = FSV{Float64}(undef, 3)
+            @test length(v) == 3
+            test_inferred_noalloc(((a, b) -> a .= b), FSV{Float64}, (v, 1:3))
+            @test v == 1:3
+            test_inferred(similar, FSV{Float64}, (v,))
+            test_inferred(similar, FSV{Int}, (v, Int))
+            test_inferred(copy, FSV{Float64}, (v,))
+            test_inferred(zero, FSV{Float64}, (v,))
+            test_inferred(similar, FSV{Int}, (FSV{Int}, (2,)))
+            test_inferred(similar, FSV{Int}, (FSA{Int}, (2,)))
+            example_abstract_vectors = (7:9, [7, 8, 9], OffsetArray([7, 8, 9], 1:3))
+            test_convert = function(T, a)
+                test_inferred(convert, FSV{Int}, (T, a))
+                c = convert(T, a)
+                test_inferred(convert, FSV{Int}, (T, c))
+                @test c == a
+                @test c === convert(T, c)
+            end
+            for T ∈ (FSA, FSV)
+                for a ∈ example_abstract_vectors
+                    test_convert(T, a)
+                end
+            end
+            for T ∈ (FSA{Int}, FSV{Int})
+                for S ∈ (Int, Float64)
+                    for a ∈ map((c -> map(S, c)), example_abstract_vectors)
+                        test_convert(T, a)
+                    end
+                end
             end
         end
-        for T ∈ (FSA{<:Any,-1}, FSA{Int,-1}, FSA{Int,3.1})
-            iterator = (7:8, (7, 8))
-            @test_throws ArgumentError collect_as(T, iterator)
-        end
-        for T ∈ (FSA{3}, FSV{3})
-            iterator = (7:8, (7, 8))
-            @test_throws TypeError collect_as(T, iterator)
-        end
-        struct Iter{E,N,I<:Integer}
-            size::NTuple{N,I}
-            length::I
-            val::E
-        end
-        function Base.iterate(i::Iter)
-            l = i.length
-            iterate(i, max(zero(l), l))
-        end
-        function Base.iterate(i::Iter, state::Int)
-            if iszero(state)
-                nothing
-            else
-                (i.val, state - 1)
+
+        @testset "FixedSizeMatrix" begin
+            m = FSM{Float64}(undef, 3, 3)
+            m_ref = reshape(1:9, size(m))
+            @test length(m) == 9
+            test_inferred_noalloc(((a, b) -> a .= b), FSM{Float64}, (m, m_ref))
+            @test m == m_ref
+            test_inferred(similar, FSM{Float64}, (m,))
+            test_inferred(similar, FSM{Int}, (m, Int))
+            test_inferred(copy, FSM{Float64}, (m,))
+            test_inferred(zero, FSM{Float64}, (m,))
+            test_inferred(similar, FSM{Int}, (FSM{Int}, (2, 3)))
+            test_inferred(similar, FSM{Int}, (FSA{Int}, (2, 3)))
+            example_abstract_matrices = (
+                reshape(1:9, (3, 3)),
+                OffsetArray(reshape(1:9, (3, 3)), 1:3, 1:3),
+            )
+            test_convert = function(T, a)
+                test_inferred(convert, FSM{Int}, (T, a))
+                c = convert(T, a)
+                test_inferred(convert, FSM{Int}, (T, c))
+                @test c == a
+                @test c === convert(T, c)
+            end
+            for T ∈ (FSA, FSM)
+                for a ∈ example_abstract_matrices
+                    test_convert(T, a)
+                end
+            end
+            for T ∈ (FSA{Int}, FSM{Int})
+                for S ∈ (Int, Float64)
+                    for a ∈ map((c -> map(S, c)), example_abstract_matrices)
+                        test_convert(T, a)
+                    end
+                end
             end
         end
-        Base.IteratorSize(::Type{<:Iter{<:Any,N}}) where {N} = Base.HasShape{N}()
-        Base.length(i::Iter) = i.length
-        Base.size(i::Iter) = i.size
-        Base.eltype(::Type{<:Iter{E}}) where {E} = E
-        @testset "buggy iterator with mismatched `size` and `length" begin
-            for iterator ∈ (Iter((), 0, 7), Iter((3, 2), 5, 7))
-                E = eltype(iterator)
-                dim_count = length(size(iterator))
-                for T ∈ (FSA, FSA{E}, FSA{<:Any,dim_count}, FSA{E,dim_count})
+
+        @testset "`map`" begin
+            for dim_count ∈ 0:3
+                size = ntuple(Returns(3), dim_count)
+                a = FSA{Int, dim_count}(undef, size)
+                for v ∈ (3, 3.1, nothing)
+                    args = (Returns(v), a)
+                    @test all(==(v), map(args...))
+                    test_inferred(map, FSA{typeof(v), dim_count}, args)
+                end
+            end
+        end
+
+        @testset "broadcasting" begin
+            TVI = FSV{Int}
+            TVF = FSV{Float64}
+            v3 = TVI(1:3)
+            vf3 = TVF(1:3)
+            bp = (x, y) -> x .+ y
+            bm = (x, y) -> x .* y
+            test_inferred(+,  TVI, (v3, v3))
+            test_inferred(bp, TVI, (v3, v3))
+            test_inferred(bm, TVI, (v3, v3))
+            test_inferred(+,  TVF, (v3, vf3))
+            test_inferred(bp, TVF, (v3, vf3))
+            test_inferred(bm, TVF, (v3, vf3))
+            test_inferred(bp, TVI, (v3,  3))
+            test_inferred(bm, TVI, (v3,  3))
+            test_inferred(bp, TVF, (v3, .3))
+            test_inferred(bm, TVF, (v3, .3))
+            @testset "matrices" begin
+                TMI = FSM{Int}
+                TMF = FSM{Float64}
+                m33 = TMI(undef, 3, 3)
+                m13 = TMI(undef, 1, 3)
+                m31 = TMI(undef, 3, 1)
+                test_inferred(+,  TMI, (m33, m33))
+                test_inferred(bp, TMI, (m33, m33))
+                test_inferred(bm, TMI, (m33, m33))
+                test_inferred(bp, TMI, (m33, m13))
+                test_inferred(bm, TMI, (m33, m13))
+                test_inferred(bp, TMI, (m33, m31))
+                test_inferred(bm, TMI, (m33, m31))
+                test_inferred(bp, TMI, (m33, v3 ))
+                test_inferred(bm, TMI, (m33, v3 ))
+                test_inferred(bp, TMF, (m33, vf3))
+                test_inferred(bm, TMF, (m33, vf3))
+                test_inferred(bp, TMI, (m33,   3))
+                test_inferred(bm, TMI, (m33,   3))
+                test_inferred(bp, TMF, (m33,  .3))
+                test_inferred(bm, TMF, (m33,  .3))
+            end
+        end
+
+        @testset "`isassigned`" begin
+            for dim_count ∈ 0:3
+                for elem_type ∈ (Int, FSM{Nothing})
+                    size = ntuple(Returns(3), dim_count)
+                    a = FSA{elem_type, dim_count}(undef, size)
+                    for i_style ∈ (IndexLinear(), IndexCartesian())
+                        for i ∈ eachindex(i_style, a)
+                            @test isassigned(a, i) == isbitstype(elem_type)
+                            test_inferred_noalloc(isassigned, Bool, (a, i))
+                        end
+                    end
+                end
+            end
+            @testset "some assigned" begin
+                a = FSM{FSM{Nothing}}(undef, 3, 3)
+                assigned_inds = ((1, 2), (2, 3), (3, 3))
+                for ij ∈ assigned_inds
+                    a[ij...] = FSM{Nothing}(undef, 1, 1)
+                end
+                for ij ∈ Iterators.product(1:3, 1:3)
+                    @test isassigned(a, ij...) == (ij ∈ assigned_inds)
+                    test_inferred_noalloc(isassigned, Bool, (a, ij...))
+                end
+            end
+        end
+
+        @testset "`copyto!`" begin
+            for (D, S) ∈ (
+                (Vector, FSV),
+                (Memory, FSV),
+                (FSV, Vector),
+                (FSV, Memory),
+                (FSV, FSV),
+            )
+                for E ∈ (Float64, Int)
+                    s = S{E}(undef, 5)
+                    s .= 1:5
+                    d = D{Float64}(undef, 5)
+                    test_inferred_noalloc(copyto!, D{Float64}, (d, s))
+                    @test copyto!(d, s) == 1:5
+                    args = (d, 1, s, 1, length(s))
+                    test_inferred_noalloc(copyto!, D{Float64}, args)
+                    @test copyto!(args...) == 1:5
+                    @test_throws ArgumentError copyto!(d, 1, s, 1, -1)
+                end
+            end
+        end
+
+        @testset "LinearAlgebra" begin
+            @testset "$T" for T in (Float16, Float32, Float64)
+                v = randn(T, 8)
+                v_fixed = FSV(v)
+                test_inferred(+, FSV{T}, (v_fixed, v_fixed))
+                v_sum = v_fixed + v_fixed
+                @test v_sum ≈ v + v
+                test_inferred(((x, y) -> x * y'), FSM{T}, (v_fixed, v_fixed))
+                v_mul = v_fixed * v_fixed'
+                @test v_mul ≈ v * v'
+
+                M = randn(T, 8, 8)
+                M_fixed = FSM(M)
+                test_inferred(+, FSM{T}, (M_fixed, M_fixed))
+                M_sum = M_fixed + M_fixed
+                @test M_sum ≈ M + M
+                test_inferred(*, FSM{T}, (M_fixed, M_fixed))
+                M_mul = M_fixed * M_fixed
+                @test M_mul ≈ M * M
+            end
+        end
+
+        @testset "`pointer`" begin
+            for elem_type ∈ (Int8, Int16, Int32, Int64)
+                for dim_count ∈ 0:4
+                    siz = ntuple(Returns(2), dim_count)
+                    arr = FSA{elem_type, dim_count}(undef, siz)
+                    @test pointer(arr) === pointer(arr, 1) === pointer(arr, 2) - sizeof(elem_type)
+                    test_inferred_noalloc(pointer, Ptr{elem_type}, (arr,))
+                    test_inferred_noalloc(pointer, Ptr{elem_type}, (arr, 1))
+                end
+            end
+        end
+
+        @testset "`reshape`" begin
+            length_to_shapes = Dict(
+                (0 => ((0,), (0, 0), (0, 1), (1, 0), (1, 0, 0), (0, 0, 1))),
+                (1 => ((), (1,), (1, 1), (1, 1, 1))),
+                (2 => ((2,), (1, 2), (2, 1), (1, 2, 1))),
+                (3 => ((3,), (1, 3), (3, 1), (1, 3, 1))),
+                (4 => ((4,), (1, 4), (4, 1), (2, 2), (1, 2, 2), (2, 1, 2))),
+                (6 => ((6,), (1, 6), (6, 1), (2, 3), (3, 2), (1, 3, 2), (2, 1, 3))),
+            )
+            for elem_type ∈ (Int, Number, Union{Nothing,Int})
+                for len ∈ keys(length_to_shapes)
+                    shapes = length_to_shapes[len]
+                    for shape1 ∈ shapes
+                        a = FSA{elem_type,length(shape1)}(undef, shape1)
+                        @test_throws DimensionMismatch reshape(a, length(a)+1)
+                        @test_throws DimensionMismatch reshape(a, length(a)+1, 1)
+                        @test_throws DimensionMismatch reshape(a, 1, length(a)+1)
+                        for shape2 ∈ shapes
+                            @test prod(shape1) === prod(shape2) === len  # meta
+                            T = FSA{elem_type,length(shape2)}
+                            test_inferred_noalloc(reshape, T, (a, shape2))
+                            test_inferred_noalloc(reshape, T, (a, shape2...))
+                            b = reshape(a, shape2)
+                            @test size(b) === shape2
+                            @test a.mem === b.mem
+                            @test a === reshape(b, shape1)
+                        end
+                    end
+                end
+            end
+        end
+
+        @testset "`collect_as`" begin
+            for T ∈ (FSA, FSV, FSA{Int}, FSV{Int})
+                for iterator ∈ (Iterators.repeated(7), Iterators.cycle(7))
                     @test_throws ArgumentError collect_as(T, iterator)
                 end
             end
-        end
-        iterators = (
-            (), (7,), (7, 8), 7, (7 => 8), Ref(7), fill(7),
-            (i for i ∈ 1:3), ((i + 100*j) for i ∈ 1:3, j ∈ 1:2), Iterators.repeated(7, 2),
-            (i for i ∈ 7:9 if i==8), 7:8, 8:7, map(BigInt, 7:8), Int[], [7], [7 8],
-            Iter((), 1, 7), Iter((3,), 3, 7), Iter((3, 2), 6, 7),
-        )
-        abstract_array_params(::AbstractArray{T,N}) where {T,N} = (T, N)
-        @testset "iterator: $iterator" for iterator ∈ iterators
-            a = collect(iterator)
-            (E, dim_count) = abstract_array_params(a)
-            af = collect(Float64, iterator)
-            @test abstract_array_params(af) == (Float64, dim_count)  # meta
-            @test_throws MethodError collect_as(FSA{E,dim_count+1}, iterator)
-            for T ∈ (FSA, FSA{<:Any,dim_count})
-                fsa = collect_as(T, iterator)
-                @test a == fsa
-                @test first(abstract_array_params(fsa)) <: E
+            for T ∈ (FSA{<:Any,-1}, FSA{Int,-1}, FSA{Int,3.1})
+                iterator = (7:8, (7, 8))
+                @test_throws ArgumentError collect_as(T, iterator)
             end
-            for T ∈ (FSA{E}, FSA{E,dim_count})
-                test_inferred(collect_as, FSA{E,dim_count}, (T, iterator))
-                fsa = collect_as(T, iterator)
-                @test a == fsa
-                @test first(abstract_array_params(fsa)) <: E
+            for T ∈ (FSA{3}, FSV{3})
+                iterator = (7:8, (7, 8))
+                @test_throws TypeError collect_as(T, iterator)
             end
-            for T ∈ (FSA{Float64}, FSA{Float64,dim_count})
-                test_inferred(collect_as, FSA{Float64,dim_count}, (T, iterator))
-                fsa = collect_as(T, iterator)
-                @test af == fsa
-                @test first(abstract_array_params(fsa)) <: Float64
+            struct Iter{E,N,I<:Integer}
+                size::NTuple{N,I}
+                length::I
+                val::E
+            end
+            function Base.iterate(i::Iter)
+                l = i.length
+                iterate(i, max(zero(l), l))
+            end
+            function Base.iterate(i::Iter, state::Int)
+                if iszero(state)
+                    nothing
+                else
+                    (i.val, state - 1)
+                end
+            end
+            Base.IteratorSize(::Type{<:Iter{<:Any,N}}) where {N} = Base.HasShape{N}()
+            Base.length(i::Iter) = i.length
+            Base.size(i::Iter) = i.size
+            Base.eltype(::Type{<:Iter{E}}) where {E} = E
+            @testset "buggy iterator with mismatched `size` and `length" begin
+                for iterator ∈ (Iter((), 0, 7), Iter((3, 2), 5, 7))
+                    E = eltype(iterator)
+                    dim_count = length(size(iterator))
+                    for T ∈ (FSA, FSA{E}, FSA{<:Any,dim_count}, FSA{E,dim_count})
+                        @test_throws ArgumentError collect_as(T, iterator)
+                    end
+                end
+            end
+            iterators = (
+                (), (7,), (7, 8), 7, (7 => 8), Ref(7), fill(7),
+                (i for i ∈ 1:3), ((i + 100*j) for i ∈ 1:3, j ∈ 1:2), Iterators.repeated(7, 2),
+                (i for i ∈ 7:9 if i==8), 7:8, 8:7, map(BigInt, 7:8), Int[], [7], [7 8],
+                Iter((), 1, 7), Iter((3,), 3, 7), Iter((3, 2), 6, 7),
+            )
+            abstract_array_params(::AbstractArray{T,N}) where {T,N} = (T, N)
+            @testset "iterator: $iterator" for iterator ∈ iterators
+                a = collect(iterator)
+                (E, dim_count) = abstract_array_params(a)
+                af = collect(Float64, iterator)
+                @test abstract_array_params(af) == (Float64, dim_count)  # meta
+                @test_throws MethodError collect_as(FSA{E,dim_count+1}, iterator)
+                for T ∈ (FSA, FSA{<:Any,dim_count})
+                    fsa = collect_as(T, iterator)
+                    @test a == fsa
+                    @test first(abstract_array_params(fsa)) <: E
+                end
+                for T ∈ (FSA{E}, FSA{E,dim_count})
+                    test_inferred(collect_as, FSA{E,dim_count}, (T, iterator))
+                    fsa = collect_as(T, iterator)
+                    @test a == fsa
+                    @test first(abstract_array_params(fsa)) <: E
+                end
+                for T ∈ (FSA{Float64}, FSA{Float64,dim_count})
+                    test_inferred(collect_as, FSA{Float64,dim_count}, (T, iterator))
+                    fsa = collect_as(T, iterator)
+                    @test af == fsa
+                    @test first(abstract_array_params(fsa)) <: Float64
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,11 +68,17 @@ end
         end
     end
 
+    storage_types = (Memory, Vector, fsv(Memory), fsv(Vector), fsv(fsv(Memory)))
+    storage_type = first(storage_types)
+    FSV = fsv(storage_type)
+    FSM = fsm(storage_type)
+    FSA = fsa(storage_type)
+
     @testset "Constructors" begin
         for dim_count ∈ 0:4
             siz = ntuple(Returns(2), dim_count)
-            T = FixedSizeArray{Float64}
-            R = FixedSizeArray{Float64,dim_count}
+            T = FSA{Float64}
+            R = FSA{Float64,dim_count}
             for sz ∈ (siz, map(BigInt, siz))
                 for args ∈ ((undef, sz), (undef, sz...))
                     test_inferred(   R, args)
@@ -83,34 +89,34 @@ end
         for offset ∈ (-1, 0, 2, 3)
             ax = offset:(offset + 1)
             oa = OffsetArray([10, 20], ax)
-            @test_throws DimensionMismatch FixedSizeArray(oa)
-            @test_throws DimensionMismatch FixedSizeVector(oa)
-            @test_throws DimensionMismatch FixedSizeArray{Int}(oa)
-            @test_throws DimensionMismatch FixedSizeVector{Int}(oa)
+            @test_throws DimensionMismatch FSA(oa)
+            @test_throws DimensionMismatch FSV(oa)
+            @test_throws DimensionMismatch FSA{Int}(oa)
+            @test_throws DimensionMismatch FSV{Int}(oa)
         end
         @testset "taken from Julia's test/core.jl" begin
             # inspired by:
             # https://github.com/JuliaLang/julia/blob/83929ad883c97fa4376618c4559b74f6ada7a3ce/test/core.jl#L7211-L7228
             b = prevpow(2, typemax(Int))
-            test_inferred(FixedSizeArray{Int}, FixedSizeArray{Int,3}, (undef, 0, b, b))
-            test_inferred(FixedSizeArray{Int}, FixedSizeArray{Int,3}, (undef, b, b, 0))
-            test_inferred(FixedSizeArray{Int}, FixedSizeArray{Int,5}, (undef, b, b, 0, b, b))
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, b, b)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, 1, b, b)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, 0, -10)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, -10, 0)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, -1, -1)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, 0, -4, -4)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, -4, 1, 0)
-            @test_throws ArgumentError FixedSizeArray{Int}(undef, -4, -4, 1)
+            test_inferred(FSA{Int}, FSA{Int,3}, (undef, 0, b, b))
+            test_inferred(FSA{Int}, FSA{Int,3}, (undef, b, b, 0))
+            test_inferred(FSA{Int}, FSA{Int,5}, (undef, b, b, 0, b, b))
+            @test_throws ArgumentError FSA{Int}(undef, b, b)
+            @test_throws ArgumentError FSA{Int}(undef, 1, b, b)
+            @test_throws ArgumentError FSA{Int}(undef, 0, -10)
+            @test_throws ArgumentError FSA{Int}(undef, -10, 0)
+            @test_throws ArgumentError FSA{Int}(undef, -1, -1)
+            @test_throws ArgumentError FSA{Int}(undef, 0, -4, -4)
+            @test_throws ArgumentError FSA{Int}(undef, -4, 1, 0)
+            @test_throws ArgumentError FSA{Int}(undef, -4, -4, 1)
         end
-        @test_throws ArgumentError FixedSizeArray{Float64,1}(undef, -1)
-        @test_throws ArgumentError FixedSizeArray{Float64,1}(undef, (-1,))
-        @test_throws ArgumentError FixedSizeArray{Float64,2}(undef, -1, -1)
-        @test_throws ArgumentError FixedSizeArray{Float64,2}(undef, typemax(Int), 0)
-        @test_throws ArgumentError FixedSizeArray{Float64,2}(undef, typemax(Int), typemax(Int))
-        @test_throws ArgumentError FixedSizeArray{Float64,3}(undef, typemax(Int)-1, typemax(Int)-1, 2)
-        @test_throws ArgumentError FixedSizeArray{Float64,4}(undef, typemax(Int)-1, typemax(Int)-1, 2, 4)
+        @test_throws ArgumentError FSA{Float64,1}(undef, -1)
+        @test_throws ArgumentError FSA{Float64,1}(undef, (-1,))
+        @test_throws ArgumentError FSA{Float64,2}(undef, -1, -1)
+        @test_throws ArgumentError FSA{Float64,2}(undef, typemax(Int), 0)
+        @test_throws ArgumentError FSA{Float64,2}(undef, typemax(Int), typemax(Int))
+        @test_throws ArgumentError FSA{Float64,3}(undef, typemax(Int)-1, typemax(Int)-1, 2)
+        @test_throws ArgumentError FSA{Float64,4}(undef, typemax(Int)-1, typemax(Int)-1, 2, 4)
         @testset "negative dimension size" begin
             for n ∈ 2:4
                 funs = (
@@ -123,38 +129,38 @@ end
                 fun = f -> ntuple(f, n)
                 sizes = map(fun, funs)
                 for siz ∈ sizes
-                    @test_throws ArgumentError FixedSizeArray{Float64,n}(undef, siz)
-                    @test_throws ArgumentError FixedSizeArray{Float64,n}(undef, siz...)
+                    @test_throws ArgumentError FSA{Float64,n}(undef, siz)
+                    @test_throws ArgumentError FSA{Float64,n}(undef, siz...)
                 end
             end
         end
     end
 
     @testset "FixedSizeVector" begin
-        v = FixedSizeVector{Float64}(undef, 3)
+        v = FSV{Float64}(undef, 3)
         @test length(v) == 3
-        test_inferred_noalloc(((a, b) -> a .= b), FixedSizeVector{Float64}, (v, 1:3))
+        test_inferred_noalloc(((a, b) -> a .= b), FSV{Float64}, (v, 1:3))
         @test v == 1:3
-        test_inferred(similar, FixedSizeVector{Float64}, (v,))
-        test_inferred(similar, FixedSizeVector{Int}, (v, Int))
-        test_inferred(copy, FixedSizeVector{Float64}, (v,))
-        test_inferred(zero, FixedSizeVector{Float64}, (v,))
-        test_inferred(similar, FixedSizeVector{Int}, (FixedSizeVector{Int}, (2,)))
-        test_inferred(similar, FixedSizeVector{Int}, (FixedSizeArray{Int}, (2,)))
+        test_inferred(similar, FSV{Float64}, (v,))
+        test_inferred(similar, FSV{Int}, (v, Int))
+        test_inferred(copy, FSV{Float64}, (v,))
+        test_inferred(zero, FSV{Float64}, (v,))
+        test_inferred(similar, FSV{Int}, (FSV{Int}, (2,)))
+        test_inferred(similar, FSV{Int}, (FSA{Int}, (2,)))
         example_abstract_vectors = (7:9, [7, 8, 9], OffsetArray([7, 8, 9], 1:3))
         test_convert = function(T, a)
-            test_inferred(convert, FixedSizeVector{Int}, (T, a))
+            test_inferred(convert, FSV{Int}, (T, a))
             c = convert(T, a)
-            test_inferred(convert, FixedSizeVector{Int}, (T, c))
+            test_inferred(convert, FSV{Int}, (T, c))
             @test c == a
             @test c === convert(T, c)
         end
-        for T ∈ (FixedSizeArray, FixedSizeVector)
+        for T ∈ (FSA, FSV)
             for a ∈ example_abstract_vectors
                 test_convert(T, a)
             end
         end
-        for T ∈ (FixedSizeArray{Int}, FixedSizeVector{Int})
+        for T ∈ (FSA{Int}, FSV{Int})
             for S ∈ (Int, Float64)
                 for a ∈ map((c -> map(S, c)), example_abstract_vectors)
                     test_convert(T, a)
@@ -164,34 +170,34 @@ end
     end
 
     @testset "FixedSizeMatrix" begin
-        m = FixedSizeMatrix{Float64}(undef, 3, 3)
+        m = FSM{Float64}(undef, 3, 3)
         m_ref = reshape(1:9, size(m))
         @test length(m) == 9
-        test_inferred_noalloc(((a, b) -> a .= b), FixedSizeMatrix{Float64}, (m, m_ref))
+        test_inferred_noalloc(((a, b) -> a .= b), FSM{Float64}, (m, m_ref))
         @test m == m_ref
-        test_inferred(similar, FixedSizeMatrix{Float64}, (m,))
-        test_inferred(similar, FixedSizeMatrix{Int}, (m, Int))
-        test_inferred(copy, FixedSizeMatrix{Float64}, (m,))
-        test_inferred(zero, FixedSizeMatrix{Float64}, (m,))
-        test_inferred(similar, FixedSizeMatrix{Int}, (FixedSizeMatrix{Int}, (2, 3)))
-        test_inferred(similar, FixedSizeMatrix{Int}, (FixedSizeArray{Int}, (2, 3)))
+        test_inferred(similar, FSM{Float64}, (m,))
+        test_inferred(similar, FSM{Int}, (m, Int))
+        test_inferred(copy, FSM{Float64}, (m,))
+        test_inferred(zero, FSM{Float64}, (m,))
+        test_inferred(similar, FSM{Int}, (FSM{Int}, (2, 3)))
+        test_inferred(similar, FSM{Int}, (FSA{Int}, (2, 3)))
         example_abstract_matrices = (
             reshape(1:9, (3, 3)),
             OffsetArray(reshape(1:9, (3, 3)), 1:3, 1:3),
         )
         test_convert = function(T, a)
-            test_inferred(convert, FixedSizeMatrix{Int}, (T, a))
+            test_inferred(convert, FSM{Int}, (T, a))
             c = convert(T, a)
-            test_inferred(convert, FixedSizeMatrix{Int}, (T, c))
+            test_inferred(convert, FSM{Int}, (T, c))
             @test c == a
             @test c === convert(T, c)
         end
-        for T ∈ (FixedSizeArray, FixedSizeMatrix)
+        for T ∈ (FSA, FSM)
             for a ∈ example_abstract_matrices
                 test_convert(T, a)
             end
         end
-        for T ∈ (FixedSizeArray{Int}, FixedSizeMatrix{Int})
+        for T ∈ (FSA{Int}, FSM{Int})
             for S ∈ (Int, Float64)
                 for a ∈ map((c -> map(S, c)), example_abstract_matrices)
                     test_convert(T, a)
@@ -203,18 +209,18 @@ end
     @testset "`map`" begin
         for dim_count ∈ 0:3
             size = ntuple(Returns(3), dim_count)
-            a = FixedSizeArray{Int, dim_count}(undef, size)
+            a = FSA{Int, dim_count}(undef, size)
             for v ∈ (3, 3.1, nothing)
                 args = (Returns(v), a)
                 @test all(==(v), map(args...))
-                test_inferred(map, FixedSizeArray{typeof(v), dim_count}, args)
+                test_inferred(map, FSA{typeof(v), dim_count}, args)
             end
         end
     end
 
     @testset "broadcasting" begin
-        TVI = FixedSizeVector{Int}
-        TVF = FixedSizeVector{Float64}
+        TVI = FSV{Int}
+        TVF = FSV{Float64}
         v3 = TVI(1:3)
         vf3 = TVF(1:3)
         bp = (x, y) -> x .+ y
@@ -230,8 +236,8 @@ end
         test_inferred(bp, TVF, (v3, .3))
         test_inferred(bm, TVF, (v3, .3))
         @testset "matrices" begin
-            TMI = FixedSizeMatrix{Int}
-            TMF = FixedSizeMatrix{Float64}
+            TMI = FSM{Int}
+            TMF = FSM{Float64}
             m33 = TMI(undef, 3, 3)
             m13 = TMI(undef, 1, 3)
             m31 = TMI(undef, 3, 1)
@@ -255,9 +261,9 @@ end
 
     @testset "`isassigned`" begin
         for dim_count ∈ 0:3
-            for elem_type ∈ (Int, FixedSizeMatrix{Nothing})
+            for elem_type ∈ (Int, FSM{Nothing})
                 size = ntuple(Returns(3), dim_count)
-                a = FixedSizeArray{elem_type, dim_count}(undef, size)
+                a = FSA{elem_type, dim_count}(undef, size)
                 for i_style ∈ (IndexLinear(), IndexCartesian())
                     for i ∈ eachindex(i_style, a)
                         @test isassigned(a, i) == isbitstype(elem_type)
@@ -267,10 +273,10 @@ end
             end
         end
         @testset "some assigned" begin
-            a = FixedSizeMatrix{FixedSizeMatrix{Nothing}}(undef, 3, 3)
+            a = FSM{FSM{Nothing}}(undef, 3, 3)
             assigned_inds = ((1, 2), (2, 3), (3, 3))
             for ij ∈ assigned_inds
-                a[ij...] = FixedSizeMatrix{Nothing}(undef, 1, 1)
+                a[ij...] = FSM{Nothing}(undef, 1, 1)
             end
             for ij ∈ Iterators.product(1:3, 1:3)
                 @test isassigned(a, ij...) == (ij ∈ assigned_inds)
@@ -281,11 +287,11 @@ end
 
     @testset "`copyto!`" begin
         for (D, S) ∈ (
-            (Vector, FixedSizeVector),
-            (Memory, FixedSizeVector),
-            (FixedSizeVector, Vector),
-            (FixedSizeVector, Memory),
-            (FixedSizeVector, FixedSizeVector),
+            (Vector, FSV),
+            (Memory, FSV),
+            (FSV, Vector),
+            (FSV, Memory),
+            (FSV, FSV),
         )
             for E ∈ (Float64, Int)
                 s = S{E}(undef, 5)
@@ -304,20 +310,20 @@ end
     @testset "LinearAlgebra" begin
         @testset "$T" for T in (Float16, Float32, Float64)
             v = randn(T, 8)
-            v_fixed = FixedSizeVector(v)
-            test_inferred(+, FixedSizeVector{T}, (v_fixed, v_fixed))
+            v_fixed = FSV(v)
+            test_inferred(+, FSV{T}, (v_fixed, v_fixed))
             v_sum = v_fixed + v_fixed
             @test v_sum ≈ v + v
-            test_inferred(((x, y) -> x * y'), FixedSizeMatrix{T}, (v_fixed, v_fixed))
+            test_inferred(((x, y) -> x * y'), FSM{T}, (v_fixed, v_fixed))
             v_mul = v_fixed * v_fixed'
             @test v_mul ≈ v * v'
 
             M = randn(T, 8, 8)
-            M_fixed = FixedSizeMatrix(M)
-            test_inferred(+, FixedSizeMatrix{T}, (M_fixed, M_fixed))
+            M_fixed = FSM(M)
+            test_inferred(+, FSM{T}, (M_fixed, M_fixed))
             M_sum = M_fixed + M_fixed
             @test M_sum ≈ M + M
-            test_inferred(*, FixedSizeMatrix{T}, (M_fixed, M_fixed))
+            test_inferred(*, FSM{T}, (M_fixed, M_fixed))
             M_mul = M_fixed * M_fixed
             @test M_mul ≈ M * M
         end
@@ -327,7 +333,7 @@ end
         for elem_type ∈ (Int8, Int16, Int32, Int64)
             for dim_count ∈ 0:4
                 siz = ntuple(Returns(2), dim_count)
-                arr = FixedSizeArray{elem_type, dim_count}(undef, siz)
+                arr = FSA{elem_type, dim_count}(undef, siz)
                 @test pointer(arr) === pointer(arr, 1) === pointer(arr, 2) - sizeof(elem_type)
                 test_inferred_noalloc(pointer, Ptr{elem_type}, (arr,))
                 test_inferred_noalloc(pointer, Ptr{elem_type}, (arr, 1))
@@ -348,13 +354,13 @@ end
             for len ∈ keys(length_to_shapes)
                 shapes = length_to_shapes[len]
                 for shape1 ∈ shapes
-                    a = FixedSizeArray{elem_type,length(shape1)}(undef, shape1)
+                    a = FSA{elem_type,length(shape1)}(undef, shape1)
                     @test_throws DimensionMismatch reshape(a, length(a)+1)
                     @test_throws DimensionMismatch reshape(a, length(a)+1, 1)
                     @test_throws DimensionMismatch reshape(a, 1, length(a)+1)
                     for shape2 ∈ shapes
                         @test prod(shape1) === prod(shape2) === len  # meta
-                        T = FixedSizeArray{elem_type,length(shape2)}
+                        T = FSA{elem_type,length(shape2)}
                         test_inferred_noalloc(reshape, T, (a, shape2))
                         test_inferred_noalloc(reshape, T, (a, shape2...))
                         b = reshape(a, shape2)
@@ -368,16 +374,16 @@ end
     end
 
     @testset "`collect_as`" begin
-        for T ∈ (FixedSizeArray, FixedSizeVector, FixedSizeArray{Int}, FixedSizeVector{Int})
+        for T ∈ (FSA, FSV, FSA{Int}, FSV{Int})
             for iterator ∈ (Iterators.repeated(7), Iterators.cycle(7))
                 @test_throws ArgumentError collect_as(T, iterator)
             end
         end
-        for T ∈ (FixedSizeArray{<:Any,-1}, FixedSizeArray{Int,-1}, FixedSizeArray{Int,3.1})
+        for T ∈ (FSA{<:Any,-1}, FSA{Int,-1}, FSA{Int,3.1})
             iterator = (7:8, (7, 8))
             @test_throws ArgumentError collect_as(T, iterator)
         end
-        for T ∈ (FixedSizeArray{3}, FixedSizeVector{3})
+        for T ∈ (FSA{3}, FSV{3})
             iterator = (7:8, (7, 8))
             @test_throws TypeError collect_as(T, iterator)
         end
@@ -405,7 +411,7 @@ end
             for iterator ∈ (Iter((), 0, 7), Iter((3, 2), 5, 7))
                 E = eltype(iterator)
                 dim_count = length(size(iterator))
-                for T ∈ (FixedSizeArray, FixedSizeArray{E}, FixedSizeArray{<:Any,dim_count}, FixedSizeArray{E,dim_count})
+                for T ∈ (FSA, FSA{E}, FSA{<:Any,dim_count}, FSA{E,dim_count})
                     @test_throws ArgumentError collect_as(T, iterator)
                 end
             end
@@ -422,20 +428,20 @@ end
             (E, dim_count) = abstract_array_params(a)
             af = collect(Float64, iterator)
             @test abstract_array_params(af) == (Float64, dim_count)  # meta
-            @test_throws MethodError collect_as(FixedSizeArray{E,dim_count+1}, iterator)
-            for T ∈ (FixedSizeArray, FixedSizeArray{<:Any,dim_count})
+            @test_throws MethodError collect_as(FSA{E,dim_count+1}, iterator)
+            for T ∈ (FSA, FSA{<:Any,dim_count})
                 fsa = collect_as(T, iterator)
                 @test a == fsa
                 @test first(abstract_array_params(fsa)) <: E
             end
-            for T ∈ (FixedSizeArray{E}, FixedSizeArray{E,dim_count})
-                test_inferred(collect_as, FixedSizeArray{E,dim_count}, (T, iterator))
+            for T ∈ (FSA{E}, FSA{E,dim_count})
+                test_inferred(collect_as, FSA{E,dim_count}, (T, iterator))
                 fsa = collect_as(T, iterator)
                 @test a == fsa
                 @test first(abstract_array_params(fsa)) <: E
             end
-            for T ∈ (FixedSizeArray{Float64}, FixedSizeArray{Float64,dim_count})
-                test_inferred(collect_as, FixedSizeArray{Float64,dim_count}, (T, iterator))
+            for T ∈ (FSA{Float64}, FSA{Float64,dim_count})
+                test_inferred(collect_as, FSA{Float64,dim_count}, (T, iterator))
                 fsa = collect_as(T, iterator)
                 @test af == fsa
                 @test first(abstract_array_params(fsa)) <: Float64


### PR DESCRIPTION
This approach isolates us from possible changes in the `GenericMemory` design while leaving open the possibility of supporting other underlying storage types in the future.

Fixes #33