### PR TITLE
Define `Base.dataids` method for FixedSizeArrays

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -392,7 +392,7 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
     collect_as_fsa_checked(iterator, spec, dim_count, len_stat)::T
 end
 
-if isdefined(Base, :dataids)
+if isdefined(Base, :dataids) && (Base.dataids isa Function)
     # This is an internal, non-public function which is nevertheless needed to
     # get good performance in some cases (e.g. broadcasting):
     # <https://github.com/JuliaArrays/FixedSizeArrays.jl/issues/63>.

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -392,4 +392,11 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
     collect_as_fsa_checked(iterator, spec, dim_count, len_stat)::T
 end
 
+if isdefined(Base, :dataids)
+    # This is an internal, non-public function which is nevertheless needed to
+    # get good performance in some cases (e.g. broadcasting):
+    # <https://github.com/JuliaArrays/FixedSizeArrays.jl/issues/63>.
+    Base.dataids(a::FixedSizeArray) = Base.dataids(a.mem)
+end
+
 end # module FixedSizeArrays


### PR DESCRIPTION
Fix #63.