### PR TITLE
Automatically skip boundschecks in `setindex!` when safe to do so

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -55,7 +55,11 @@ end
 
 Base.IndexStyle(::Type{<:FixedSizeArray}) = IndexLinear()
 Base.@propagate_inbounds Base.getindex(A::FixedSizeArray, i::Int) = A.mem[i]
-Base.@propagate_inbounds Base.setindex!(A::FixedSizeArray, v, i::Int) = A.mem[i] = v
+Base.@propagate_inbounds Base.@assume_effects :noub_if_noinbounds function Base.setindex!(A::FixedSizeArray{T}, x, i::Int) where {T}
+    @boundscheck (i - 1)%UInt < length(A)%UInt || throw(BoundsError(A, (i,)))
+    @inbounds A.mem[i] = x
+    return A
+end
 
 Base.size(a::FixedSizeArray) = a.size
 

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -56,7 +56,7 @@ end
 Base.IndexStyle(::Type{<:FixedSizeArray}) = IndexLinear()
 Base.@propagate_inbounds Base.getindex(A::FixedSizeArray, i::Int) = A.mem[i]
 Base.@propagate_inbounds Base.@assume_effects :noub_if_noinbounds function Base.setindex!(A::FixedSizeArray{T}, x, i::Int) where {T}
-    @boundscheck (i - 1)%UInt < length(A)%UInt || throw(BoundsError(A, (i,)))
+    @boundscheck checkbounds(A, i)
     @inbounds A.mem[i] = x
     return A
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,6 +185,15 @@ end
             end
         end
 
+        @testset "setindex!" begin
+            v = FSV{Float64}(undef, 2)
+            v[1] = 1
+            v[2] = 2
+            @test v[1] == 1
+            @test v[2] == 2
+            @test_throws BoundsError v[3] = 3
+        end
+
         @testset "FixedSizeVector" begin
             v = FSV{Float64}(undef, 3)
             @test length(v) == 3


### PR DESCRIPTION
Fix #65