### PR TITLE
define `propertynames(::FixedSizeArray)`

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -19,6 +19,14 @@ struct FixedSizeArray{T,N,Mem<:GenericMemory{<:Any,T}} <: DenseArray{T,N}
     end
 end
 
+function Base.propertynames(
+    # the `unused` is here because of https://github.com/JuliaLang/julia/issues/44428
+    (@nospecialize unused::FixedSizeArray),
+    ::Bool = false,
+)
+    ()
+end
+
 const FixedSizeVector{T} = FixedSizeArray{T,1}
 const FixedSizeMatrix{T} = FixedSizeArray{T,2}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,6 +125,17 @@ end
         FSM = fsm(storage_type)
         FSA = fsa(storage_type)
 
+        @testset "`propertynames`" begin
+            for dim_count ∈ 0:4
+                for T ∈ (Int, Float32)
+                    siz = ntuple(Returns(1), dim_count)
+                    arr = FSA{T}(undef, siz)
+                    test_inferred(propertynames, Tuple{}, (arr,))
+                    test_inferred(propertynames, Tuple{}, (arr, false))
+                end
+            end
+        end
+
         @testset "Constructors" begin
             for dim_count ∈ 0:4
                 siz = ntuple(Returns(2), dim_count)


### PR DESCRIPTION
Make both fields private.