### PR TITLE
introduce a custom `Broadcast.AbstractArrayStyle` subtype

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -145,10 +145,10 @@ function Base.BroadcastStyle(::Type{<:(FixedSizeArray{T, N, Mem} where {T})}) wh
 end
 
 function Base.similar(
-    bc::(Broadcast.Broadcasted{FixedSizeArrayBroadcastStyle{N, Mem}} where {N}),
+    bc::Broadcast.Broadcasted{FixedSizeArrayBroadcastStyle{N, Mem}},
     ::Type{E},
-) where {Mem,E}
-    similar((FixedSizeArray{E, N, Mem{E}} where {N}), axes(bc))
+) where {N,Mem,E}
+    similar(FixedSizeArray{E, N, Mem{E}}, axes(bc))
 end
 
 # helper functions

--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -212,13 +212,12 @@ length_status(::Base.SizeUnknown) = LengthIsUnknown()
 length_status(::Base.HasLength) = LengthIsKnown()
 length_status(::Base.HasShape) = LengthIsKnown()
 
-function check_count_value(n::Int)
+function check_count_value(n)
+    n = n::Int
     if n < 0
         throw(ArgumentError("count can't be negative"))
     end
-end
-function check_count_value(n)
-    throw(ArgumentError("count must be an `Int`"))
+    n
 end
 
 # TODO: use `SpecFSA` for implementing each `FixedSizeArray` constructor?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -443,10 +443,8 @@ end
                     @test_throws ArgumentError collect_as(T, iterator)
                 end
             end
-            for T ∈ (FSA{Int,-1}, FSA{Int,3.1})
-                iterator = (7:8, (7, 8))
-                @test_throws ArgumentError collect_as(T, iterator)
-            end
+            @test_throws ArgumentError collect_as(FSA{Int, -1}, 7:8)
+            @test_throws TypeError collect_as(FSA{Int, 3.1}, 7:8)
             for T ∈ (FSA{3}, FSV{3})
                 iterator = (7:8, (7, 8))
                 @test_throws TypeError collect_as(T, iterator)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,13 @@ function fsv(vec_type::Type{<:DenseVector})
     fsa(vec_type){T,1} where {T}
 end
 
+function test_we_do_not_own_the_call(func, arg_types)
+    function f(method)
+        FixedSizeArrays != parentmodule(method)
+    end
+    @test all(f, methods(func, arg_types))
+end
+
 @testset "FixedSizeArrays" begin
     @testset "meta" begin
         @test isempty(detect_ambiguities(Main))  # test for ambiguities in this file
@@ -65,6 +72,12 @@ end
 
     @testset "Aqua.jl" begin
         Aqua.test_all(FixedSizeArrays)
+    end
+
+    @testset "type piracy" begin
+        @testset "issue #77: type piracy of `similar`" begin
+            test_we_do_not_own_the_call(similar, Tuple{Broadcast.Broadcasted{Broadcast.ArrayStyle{Union{}}}, Type{Int}})
+        end
     end
 
     @testset "safe computation of length from dimensions size" begin


### PR DESCRIPTION
Apart from fixing the type piracy, this change moves us from `AbstractArrayStyle{Any}` to `AbstractArrayStyle{N}`. This seems like a good idea because that's what `Array` uses.

Fixes #77