### PR TITLE
move the `dataids` method to the main file

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -1,6 +1,14 @@
 module FixedSizeArrays
 
 include("FixedSizeArray.jl")
+
+if isdefined(Base, :dataids) && (Base.dataids isa Function)
+    # This is an internal, non-public function which is nevertheless needed to
+    # get good performance in some cases (e.g. broadcasting):
+    # <https://github.com/JuliaArrays/FixedSizeArrays.jl/issues/63>.
+    Base.dataids(a::FixedSizeArray) = Base.dataids(a.mem)
+end
+
 include("collect_as.jl")
 
 end # module FixedSizeArrays

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -115,10 +115,3 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
     len_stat = length_status(size_class)
     collect_as_fsa_checked(iterator, spec, dim_count, len_stat)::T
 end
-
-if isdefined(Base, :dataids) && (Base.dataids isa Function)
-    # This is an internal, non-public function which is nevertheless needed to
-    # get good performance in some cases (e.g. broadcasting):
-    # <https://github.com/JuliaArrays/FixedSizeArrays.jl/issues/63>.
-    Base.dataids(a::FixedSizeArray) = Base.dataids(a.mem)
-end


### PR DESCRIPTION
I think this may be tidier. The `FixedSizeBitArray` method would presumably go right next to this one.