### PR TITLE
rewrite `collect_as`

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -204,60 +204,12 @@ dimension_count_of(::Base.SizeUnknown) = 1
 dimension_count_of(::Base.HasLength) = 1
 dimension_count_of(::Base.HasShape{N}) where {N} = convert(Int, N)::Int
 
-struct LengthIsUnknown end
-struct LengthIsKnown end
-length_status(::Base.SizeUnknown) = LengthIsUnknown()
-length_status(::Base.HasLength) = LengthIsKnown()
-length_status(::Base.HasShape) = LengthIsKnown()
-
 function check_count_value(n)
     n = n::Int
     if n < 0
         throw(ArgumentError("count can't be negative"))
     end
     n
-end
-
-# TODO: use `SpecFSA` for implementing each `FixedSizeArray` constructor?
-struct SpecFSA{N,Mem<:DenseVector} end
-function fsa_spec_from_type(::Type{FixedSizeArray})
-    SpecFSA{nothing,default_underlying_storage_type}()
-end
-function fsa_spec_from_type(::Type{FixedSizeArray{<:Any,M}}) where {M}
-    check_count_value(M)
-    SpecFSA{M,default_underlying_storage_type}()
-end
-function fsa_spec_from_type(::Type{FixedSizeArray{E}}) where {E}
-    E::Type
-    SpecFSA{nothing,default_underlying_storage_type{E}}()
-end
-function fsa_spec_from_type(::Type{FixedSizeArray{E,M}}) where {E,M}
-    check_count_value(M)
-    E::Type
-    SpecFSA{M,default_underlying_storage_type{E}}()
-end
-function fsa_spec_from_type(::Type{FixedSizeArray{E,<:Any,V}}) where {E,V}
-    E::Type
-    V::Type{<:DenseVector{E}}
-    SpecFSA{nothing,V}()
-end
-function fsa_spec_from_type(::Type{FixedSizeArray{E,M,V}}) where {E,M,V}
-    check_count_value(M)
-    E::Type
-    V::Type{<:DenseVector{E}}
-    SpecFSA{M,V}()
-end
-for V ∈ (Vector, optional_memory..., optional_atomic_memory...)
-    T = FixedSizeArray{E,M,V{E}} where {E,M}
-    @eval begin
-        function fsa_spec_from_type(::Type{$T})
-            SpecFSA{nothing,$V}()
-        end
-        function fsa_spec_from_type(::Type{($T){<:Any,M}}) where {M}
-            check_count_value(M)
-            SpecFSA{M,$V}()
-        end
-    end
 end
 
 parent_type(::Type{<:FixedSizeArray{<:Any,<:Any,T}}) where {T} = T

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -157,5 +157,5 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
         fsv
     else
         reshape(fsv, size(iterator))
-    end
+    end::T
 end

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -55,6 +55,14 @@ function push(v::Vector, e)
     ret
 end
 
+"""
+    push!!(t::Type{<:AbstractVector}, v::Vector, e)::Vector
+
+Return a `Vector`, `r`, respecting these properties:
+* `all(r[begin:(end - 1)] .=== v)`
+* if `t` specifies an element type, `E`, `r[end] == E(e)`, otherwise `r[end] === e`
+"""
+function push!! end
 function push!!(::Type{<:AbstractVector{E}}, v::Vector{E}, e::E) where {E}
     push!(v, e)
 end

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -77,9 +77,7 @@ function empty_fsv(::Type{V}, iterator) where {V <: DenseVector}
         if isconcretetype(E)
             fsv_type_from_underlying_storage_type(V{E})(undef, 0)
         else
-            let E = Union{}
-                fsv_type_from_underlying_storage_type(V{E})(undef, 0)
-            end
+            fsv_type_from_underlying_storage_type(V{Union{}})(undef, 0)
         end
     end
 end

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -11,7 +11,7 @@ function collect_as_storage_type_helper(::Type{Storage}, ::Type{E}) where {Stora
     Storage{E}
 end
 
-function make_abstract_vector_from_tuple(::Type{V}, elems::Tuple) where {E, V <: AbstractVector{E}}
+function make_abstract_vector_from_collection_with_length(::Type{V}, elems) where {E, V <: AbstractVector{E}}
     ret = V(undef, length(elems))
     copyto!(ret, elems)
 end
@@ -23,7 +23,7 @@ end
 function make_vector_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector}
     stor = collect_as_storage_type_helper(V, eltype(elems))
     ret_type = Vector{eltype(stor)}
-    make_abstract_vector_from_tuple(ret_type, elems)
+    make_abstract_vector_from_collection_with_length(ret_type, elems)
 end
 
 function parent_type_with_default(::Type{<:(FixedSizeArray{E, N, T} where {N})}) where {E, T <: DenseVector{E}}

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -93,10 +93,10 @@ end
 """
     collect_as_fsv(V::Type{<:DenseVector}, iterator)::FixedSizeVector
 
-Collect the elements of `iterator` into a `FixedSizeVector`. The argument `V`
-specifies the underlying storage type parameter of this `FixedSizeVector`. When
-possible, the element type of the return value is also taken from `V`, otherwise it
-is determined by the types of the elements of the iterator.
+Collect the elements of `iterator` into a `FixedSizeVector`, `r`. The argument `V`
+specifies the underlying storage type parameter of `r`. When possible (specified as
+a parameter in `V`), `eltype(r)` is also taken from `V`, otherwise it is determined
+by the types of the elements of the iterator.
 
 When `V` does not provide an element type and `isempty(iterator)`, the element type
 of the return value is:

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -91,7 +91,7 @@ function empty_fsv(::Type{V}, iterator) where {V <: DenseVector}
 end
 
 """
-    collect_as_fsv(V::Type{<:DenseVector}, iterator)
+    collect_as_fsv(V::Type{<:DenseVector}, iterator)::FixedSizeVector
 
 Collect the elements of `iterator` into a `FixedSizeVector`. The argument `V`
 specifies the underlying storage type parameter of this `FixedSizeVector`. When

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -20,10 +20,6 @@ function fsv_type_from_underlying_storage_type(::Type{V}) where {E, V <: DenseVe
     FixedSizeVector{E, V}
 end
 
-function collect_as_return_type_helper(::Type{Storage}, ::Type{Vector{E}}) where {Storage <: AbstractVector, E}
-    fsv_type_from_underlying_storage_type(collect_as_storage_type_helper(Storage, E))
-end
-
 function make_vector_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector}
     stor = collect_as_storage_type_helper(V, eltype(elems))
     ret_type = Vector{eltype(stor)}
@@ -104,7 +100,8 @@ function collect_as_fsv(::Type{V}, iterator) where {V <: DenseVector}
                     break
                 end
             end
-            ret_type = collect_as_return_type_helper(V, typeof(ret))
+            ret_type_storage = collect_as_storage_type_helper(V, eltype(ret))
+            ret_type = fsv_type_from_underlying_storage_type(ret_type_storage)
             ret_type(ret)
         end
     else

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -24,17 +24,13 @@ function fsv_type_from_underlying_storage_type(::Type{V}) where {E, V <: DenseVe
     FixedSizeVector{E, V}
 end
 
-function vector_type_from_underlying_storage_type(::Type{V}) where {E, V <: AbstractVector{E}}
-    Vector{E}
-end
-
 function collect_as_return_type_helper(::Type{Storage}, ::Type{Vector{E}}) where {Storage <: AbstractVector, E}
     fsv_type_from_underlying_storage_type(collect_as_storage_type_helper(Storage, E))
 end
 
 function make_vector_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector}
     stor = collect_as_vector_type_helper(V, elems)
-    ret_type = vector_type_from_underlying_storage_type(stor)
+    ret_type = Vector{eltype(stor)}
     make_abstract_vector_from_tuple(ret_type, elems)
 end
 

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -84,6 +84,19 @@ function empty_fsv(::Type{V}, iterator) where {V <: DenseVector}
     end
 end
 
+"""
+    collect_as_fsv(V::Type{<:DenseVector}, iterator)
+
+Collect the elements of `iterator` into a `FixedSizeVector`. The argument `V`
+specifies the underlying storage type parameter of this `FixedSizeVector`. When
+possible, the element type of the return value is also taken from `V`, otherwise it
+is determined by the types of the elements of the iterator.
+
+When `V` does not provide an element type and `isempty(iterator)`, the element type
+of the return value is:
+* `eltype(iterator)`, when it's a concrete type
+* `Union{}`, otherwise
+"""
 function collect_as_fsv(::Type{V}, iterator) where {V <: DenseVector}
     es1 = iterate(iterator)  # unroll a bit to avoid unnecessary allocations and help inference
     T2 = Tuple{Any, Any}

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -32,12 +32,6 @@ function collect_as_return_type_helper(::Type{Storage}, ::Type{Vector{E}}) where
     fsv_type_from_underlying_storage_type(collect_as_storage_type_helper(Storage, E))
 end
 
-function make_fsv_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector}
-    stor = collect_as_vector_type_helper(V, elems)
-    ret_type = fsv_type_from_underlying_storage_type(stor)
-    make_abstract_vector_from_tuple(ret_type, elems)
-end
-
 function make_vector_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector}
     stor = collect_as_vector_type_helper(V, elems)
     ret_type = vector_type_from_underlying_storage_type(stor)
@@ -106,26 +100,20 @@ function collect_as_fsv(::Type{V}, iterator) where {V <: DenseVector}
     es1 = iterate(iterator)  # unroll a bit to avoid unnecessary allocations and help inference
     T2 = Tuple{Any, Any}
     if es1 isa T2
-        let (e1, s1) = es1, es2 = iterate(iterator, s1)
-            if es2 isa T2
-                let (e2, s2) = es2, state = s2, ret = make_vector_from_tuple(V, (e1, e2))
-                    while true
-                        es = iterate(iterator, state)
-                        if es isa T2
-                            let (e, s) = es
-                                state = s
-                                ret = push!!(V, ret, e)
-                            end
-                        else
-                            break
-                        end
+        let (e1, s1) = es1, state = s1, ret = make_vector_from_tuple(V, (e1,))
+            while true
+                es = iterate(iterator, state)
+                if es isa T2
+                    let (e, s) = es
+                        state = s
+                        ret = push!!(V, ret, e)
                     end
-                    ret_type = collect_as_return_type_helper(V, typeof(ret))
-                    ret_type(ret)
+                else
+                    break
                 end
-            else
-                make_fsv_from_tuple(V, (e1,))
             end
+            ret_type = collect_as_return_type_helper(V, typeof(ret))
+            ret_type(ret)
         end
     else
         empty_fsv(V, iterator)

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -162,7 +162,7 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
     output_dimension_count = checked_dimension_count_of(T, size_class)
     fsv = collect_as_fsv(mem, iterator)
     if isone(output_dimension_count)
-        fsv  # `size(iterator)` may throw in this branch so don't call it
+        fsv  # `size(iterator)` may throw in this branch
     else
         reshape(fsv, size(iterator))
     end::T

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -81,16 +81,16 @@ function push!!(::Type{<:AbstractVector}, v::Vector, e)
 end
 
 function empty_fsv(::Type{V}, ::Any) where {E, V <: DenseVector{E}}
-    FixedSizeVector{E, V}(undef, 0)
+    fsv_type_from_underlying_storage_type(V)(undef, 0)
 end
 
 function empty_fsv(::Type{V}, iterator) where {V <: DenseVector}
     let E = eltype(iterator)
         if isconcretetype(E)
-            FixedSizeVector{E, V{E}}(undef, 0)
+            fsv_type_from_underlying_storage_type(V{E})(undef, 0)
         else
             let E = Union{}
-                FixedSizeVector{E, V{E}}(undef, 0)
+                fsv_type_from_underlying_storage_type(V{E})(undef, 0)
             end
         end
     end

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -65,15 +65,25 @@ for T ∈ (Vector, optional_memory...)
     end
 end
 
-function push!!(v::Vector{E}, e::E) where {E}
-    push!(v, e)
-end
-function push!!(v::Vector, e)
+function push(v::Vector, e)
     E = typejoin(typeof(e), eltype(v))
     ret = Vector{E}(undef, length(v) + 1)
     ret = copyto!(ret, v)
     ret[end] = e
     ret
+end
+
+function push!!(::Type{<:AbstractVector{E}}, v::Vector{E}, e::E) where {E}
+    push!(v, e)
+end
+function push!!(::Type{<:AbstractVector{E}}, v::Vector{E}, e) where {E}
+    push!(v, e)
+end
+function push!!(::Type{<:AbstractVector}, v::Vector{E}, e::E) where {E}
+    push!(v, e)
+end
+function push!!(::Type{<:AbstractVector}, v::Vector, e)
+    push(v, e)
 end
 
 function empty_fsv(::Type{V}, ::Any) where {E, V <: DenseVector{E}}
@@ -104,7 +114,7 @@ function collect_as_fsv(::Type{V}, iterator) where {V <: DenseVector}
                         if es isa T2
                             let (e, s) = es
                                 state = s
-                                ret = push!!(ret, e)
+                                ret = push!!(V, ret, e)
                             end
                         else
                             break

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -105,12 +105,11 @@ of the return value is:
 """
 function collect_as_fsv(::Type{V}, iterator) where {V <: DenseVector}
     es1 = iterate(iterator)  # unroll a bit to avoid unnecessary allocations and help inference
-    T2 = Tuple{Any, Any}
-    if es1 isa T2
+    if es1 isa Tuple
         let (e1, s1) = es1, state = s1, ret = make_vector_from_tuple(V, (e1,))
             while true
                 es = iterate(iterator, state)
-                if es isa T2
+                if es isa Tuple
                     let (e, s) = es
                         state = s
                         ret = push!!(V, ret, e)

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -4,7 +4,7 @@ function throw_bottom_type()
     throw(ArgumentError("`Union{}` not expected"))
 end
 
-function collect_as_storage_type_helper(::Type{Storage}, ::Type{E}) where {S, Storage <: AbstractVector{S}, E}
+function collect_as_storage_type_helper(::Type{Storage}, ::Type) where {S, Storage <: AbstractVector{S}}
     Storage
 end
 function collect_as_storage_type_helper(::Type{Storage}, ::Type{E}) where {Storage <: AbstractVector, E}

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -162,7 +162,7 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
     output_dimension_count = checked_dimension_count_of(T, size_class)
     fsv = collect_as_fsv(mem, iterator)
     if isone(output_dimension_count)
-        fsv
+        fsv  # `size(iterator)` may throw in this branch so don't call it
     else
         reshape(fsv, size(iterator))
     end::T

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -11,10 +11,6 @@ function collect_as_storage_type_helper(::Type{Storage}, ::Type{E}) where {Stora
     Storage{E}
 end
 
-function collect_as_vector_type_helper(::Type{V}, elems::Tuple) where {V <: AbstractVector}
-    collect_as_storage_type_helper(V, eltype(elems))
-end
-
 function make_abstract_vector_from_tuple(::Type{V}, elems::Tuple) where {E, V <: AbstractVector{E}}
     ret = V(undef, length(elems))
     copyto!(ret, elems)
@@ -29,7 +25,7 @@ function collect_as_return_type_helper(::Type{Storage}, ::Type{Vector{E}}) where
 end
 
 function make_vector_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector}
-    stor = collect_as_vector_type_helper(V, elems)
+    stor = collect_as_storage_type_helper(V, eltype(elems))
     ret_type = Vector{eltype(stor)}
     make_abstract_vector_from_tuple(ret_type, elems)
 end

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -5,7 +5,7 @@ function throw_bottom_type()
 end
 
 function eltype_is_known(::Type{Storage}) where {S, Storage <: AbstractVector{S}}
-    true
+    @isdefined S
 end
 function eltype_is_known(::Type{Storage}) where {Storage <: AbstractVector}
     false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -486,6 +486,7 @@ end
                 @test collect_as(FSV, iterator) isa FSV{Union{}}
                 @test collect_as(FSV{Union{}}, iterator) isa FSV{Union{}}
                 @test collect_as(FSV{Float32}, iterator) isa FSV{Float32}
+                @test collect_as(FSV{Any}, iterator) isa FSV{Any}
             end
             @testset "`Union{}`" begin
                 @test_throws Exception collect_as(Union{}, ())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -484,6 +484,8 @@ end
             @testset "empty iterator with inexact `eltype`" begin
                 iterator = Iterators.map((x -> x + 0.3), [])
                 @test collect_as(FSV, iterator) isa FSV{Union{}}
+                @test collect_as(FSV{Union{}}, iterator) isa FSV{Union{}}
+                @test collect_as(FSV{Float32}, iterator) isa FSV{Float32}
             end
             @testset "`Union{}`" begin
                 @test_throws Exception collect_as(Union{}, ())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,7 +139,7 @@ end
         test_inferred(FixedSizeArray{Int}, return_type, (undef, (3,)))
         test_inferred(FixedSizeVector{Int}, return_type, (undef, 3))
         test_inferred(FixedSizeVector{Int}, return_type, (undef, (3,)))
-        iter = (i for i ∈ 1:3)
+        iter = Iterators.filter(iseven, 3:7)
         @test collect_as(FixedSizeArray, iter) isa return_type
         test_inferred(collect_as, return_type, (FixedSizeArray{Int}, iter))
         test_inferred(collect_as, return_type, (FixedSizeVector{Int}, iter))
@@ -468,6 +468,15 @@ end
         end
 
         @testset "`collect_as`" begin
+            @testset "empty iterator with inexact `eltype`" begin
+                iterator = Iterators.map((x -> x + 0.3), [])
+                @test collect_as(FSV, iterator) isa FSV{Union{}}
+            end
+            @testset "`Union{}`" begin
+                @test_throws Exception collect_as(Union{}, ())
+                @test_throws Exception collect_as(FixedSizeVector{Union{}, Union{}}, ())
+                @test_throws Exception collect_as(FixedSizeVector{<:Any, Union{}}, ())
+            end
             for T ∈ (FSA{Int}, FSV{Int})
                 for iterator ∈ (Iterators.repeated(7), Iterators.cycle(7))
                     @test_throws ArgumentError collect_as(T, iterator)
@@ -484,7 +493,7 @@ end
                     E = eltype(iterator)
                     dim_count = length(size(iterator))
                     for T ∈ (FSA{E}, FSA{E,dim_count})
-                        @test_throws ArgumentError collect_as(T, iterator)
+                        @test_throws DimensionMismatch collect_as(T, iterator)
                     end
                 end
             end
@@ -500,7 +509,7 @@ end
                 (E, dim_count) = abstract_array_params(a)
                 af = collect(Float64, iterator)
                 @test abstract_array_params(af) == (Float64, dim_count)  # meta
-                @test_throws MethodError collect_as(FSA{E,dim_count+1}, iterator)
+                @test_throws DimensionMismatch collect_as(FSA{E,dim_count+1}, iterator)
                 for T ∈ (FSA{E}, FSA{E,dim_count})
                     test_inferred(collect_as, FSA{E,dim_count}, (T, iterator))
                     fsa = collect_as(T, iterator)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -519,6 +519,8 @@ end
                 (i for i ∈ 7:9 if i==8), 7:8, 8:7, map(BigInt, 7:8), Int[], [7], [7 8],
                 Iter((), 1, 7), Iter((3,), 3, 7), Iter((3, 2), 6, 7),
                 (i for i ∈ (false, 0x1, 2) if Bool(2 - 1)),
+                (i for i ∈ (false, 0x1, 2) if Bool(2 - 2)),
+                (i + false for i ∈ (false, 0x1, 2) if Bool(2 - 2)),
             )
             abstract_array_params(::AbstractArray{T,N}) where {T,N} = (T, N)
             @testset "iterator: $iterator" for iterator ∈ iterators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -519,7 +519,6 @@ end
                 (i for i ∈ 7:9 if i==8), 7:8, 8:7, map(BigInt, 7:8), Int[], [7], [7 8],
                 Iter((), 1, 7), Iter((3,), 3, 7), Iter((3, 2), 6, 7),
                 (i for i ∈ (false, 0x1, 2) if Bool(2 - 1)),
-                (i for i ∈ (false, 0x1, 2) if Bool(2 - 2)),
                 (i + false for i ∈ (false, 0x1, 2) if Bool(2 - 2)),
                 Iterators.filter(<(1), Int[]),
             )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -468,6 +468,18 @@ end
         end
 
         @testset "`collect_as`" begin
+            @testset "difficult requested return type" begin
+                T = FixedSizeVectorDefault{T} where {T <: Float32}
+                iter = 3:7
+                returns = try
+                    collect_as(T, iter)
+                    true
+                catch e
+                    (e isa TypeError) || rethrow()
+                    false
+                end
+                returns && @test collect_as(T, iter) isa T
+            end
             @testset "empty iterator with inexact `eltype`" begin
                 iterator = Iterators.map((x -> x + 0.3), [])
                 @test collect_as(FSV, iterator) isa FSV{Union{}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -502,6 +502,7 @@ end
                 (i for i ∈ 1:3), ((i + 100*j) for i ∈ 1:3, j ∈ 1:2), Iterators.repeated(7, 2),
                 (i for i ∈ 7:9 if i==8), 7:8, 8:7, map(BigInt, 7:8), Int[], [7], [7 8],
                 Iter((), 1, 7), Iter((3,), 3, 7), Iter((3, 2), 6, 7),
+                (i for i ∈ (false, 0x1, 2) if Bool(2 - 1)),
             )
             abstract_array_params(::AbstractArray{T,N}) where {T,N} = (T, N)
             @testset "iterator: $iterator" for iterator ∈ iterators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -471,6 +471,7 @@ end
             @testset "difficult requested return type" begin
                 T = FixedSizeVectorDefault{T} where {T <: Float32}
                 iter = 3:7
+                # either return a value of the requested type or throw
                 returns = try
                     collect_as(T, iter)
                     true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -521,6 +521,7 @@ end
                 (i for i ∈ (false, 0x1, 2) if Bool(2 - 1)),
                 (i for i ∈ (false, 0x1, 2) if Bool(2 - 2)),
                 (i + false for i ∈ (false, 0x1, 2) if Bool(2 - 2)),
+                Iterators.filter(<(1), Int[]),
             )
             abstract_array_params(::AbstractArray{T,N}) where {T,N} = (T, N)
             @testset "iterator: $iterator" for iterator ∈ iterators


### PR DESCRIPTION
The behavior is supposed to stay the same, except for the case when the input iterator is empty.

Ideas:
* First collect into a `FixedSizeVector`.
    * Use `iterate`, without calling `length`, `size` or `axes` on the iterator.
    * Avoid using existing `collect` or `map` methods from `Base`, to prevent the output element type from depending on type inference.
    * For an empty input iterator, if the desired element type for the output is not specified, consult `eltype(iterator)`. When `!isconcretetype(eltype(iterator))`, just use `Union{}` for the output element type.
        * A drawback of this approach is type instability of `collect_as` when the output element type is not given and the iterator has neither constant-length nor exactly known element type. This is, however, required to prevent the output element type from depending on type inference.
* Once we have a `FixedSizeVector`, `reshape` it into the desired `FixedSizeArray` shape.

Fixes #72