### PR TITLE
simplify `undef`-taking constructors

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -21,6 +21,27 @@ end
 const FixedSizeVector{T} = FixedSizeArray{T,1}
 const FixedSizeMatrix{T} = FixedSizeArray{T,2}
 
+function parent_type_with_default(::Type{<:(FixedSizeArray{E, N, T} where {N})}) where {E, T <: DenseVector{E}}
+    T
+end
+function parent_type_with_default(::Type{<:FixedSizeArray{E}}) where {E}
+    default_underlying_storage_type{E}
+end
+function parent_type_with_default(::Type{<:FixedSizeArray})
+    default_underlying_storage_type
+end
+for T ∈ (Vector, optional_memory...)
+    FSA = FixedSizeArray{E, N, T{E}} where {E, N}
+    @eval begin
+        function parent_type_with_default(::Type{$FSA})
+            $T
+        end
+        function parent_type_with_default(::Type{($FSA){E, N} where {E}}) where {N}
+            $T
+        end
+    end
+end
+
 function FixedSizeArray{T,N,V}(::UndefInitializer, size::NTuple{N,Int}) where {T,N,V}
     new_fixed_size_array(V(undef, checked_dims(size))::V, size)
 end

--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -47,7 +47,7 @@ function check_ndims(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {N, FSA <:
         throw(DimensionMismatch("mismatch between dimension count in type and the length of the size tuple"))
     end
 end
-function check_ndims(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {FSA <: FixedSizeArray}
+function check_ndims(::Type{<:FixedSizeArray}, size::Tuple{Vararg{Integer}})
 end
 
 function undef_constructor(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {E, FSA <: FixedSizeArray{E}}

--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -54,7 +54,7 @@ function check_ndims(::Type{<:FixedSizeArray}, size::Tuple{Vararg{Integer}})
 end
 
 function undef_constructor(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {E, FSA <: FixedSizeArray{E}}
-    check_ndims(FSA, size)
+    size = check_ndims(FSA, size)
     s = map(Int, size)
     Mem = parent_type_with_default(FSA)
     len = checked_dims(s)

--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -43,7 +43,9 @@ for T ∈ (Vector, optional_memory...)
 end
 
 function check_ndims(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {N, FSA <: (FixedSizeArray{E, N} where {E})}
-    if N != length(size)
+    if size isa Tuple{Vararg{Any, N}}
+        size
+    else
         throw(DimensionMismatch("mismatch between dimension count in type and the length of the size tuple"))
     end
 end

--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -50,6 +50,7 @@ function check_ndims(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {N, FSA <:
     end
 end
 function check_ndims(::Type{<:FixedSizeArray}, size::Tuple{Vararg{Integer}})
+    size
 end
 
 function undef_constructor(::Type{FSA}, size::Tuple{Vararg{Integer}}) where {E, FSA <: FixedSizeArray{E}}

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -39,27 +39,6 @@ function make_vector_from_tuple(::Type{V}, elems::Tuple) where {V <: DenseVector
     make_abstract_vector_from_collection_with_length(ret_type, elems)
 end
 
-function parent_type_with_default(::Type{<:(FixedSizeArray{E, N, T} where {N})}) where {E, T <: DenseVector{E}}
-    T
-end
-function parent_type_with_default(::Type{<:FixedSizeArray{E}}) where {E}
-    default_underlying_storage_type{E}
-end
-function parent_type_with_default(::Type{<:FixedSizeArray})
-    default_underlying_storage_type
-end
-for T ∈ (Vector, optional_memory...)
-    FSA = FixedSizeArray{E, N, T{E}} where {E, N}
-    @eval begin
-        function parent_type_with_default(::Type{$FSA})
-            $T
-        end
-        function parent_type_with_default(::Type{($FSA){E, N} where {E}}) where {N}
-            $T
-        end
-    end
-end
-
 function push(v::Vector, e)
     E = typejoin(typeof(e), eltype(v))
     ret = Vector{E}(undef, length(v) + 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,10 +177,10 @@ end
                 @test_throws MethodError FSM(undef, 1, 1)
             end
             @testset "mismatched ndims" begin
-                @test_throws MethodError FSV{Int}(undef)
-                @test_throws MethodError FSV{Int}(undef, 1, 1)
-                @test_throws MethodError FSM{Int}(undef)
-                @test_throws MethodError FSM{Int}(undef, 1)
+                @test_throws DimensionMismatch FSV{Int}(undef)
+                @test_throws DimensionMismatch FSV{Int}(undef, 1, 1)
+                @test_throws DimensionMismatch FSM{Int}(undef)
+                @test_throws DimensionMismatch FSM{Int}(undef, 1)
             end
             for dim_count ∈ 0:4
                 siz = ntuple(Returns(2), dim_count)


### PR DESCRIPTION
Prevent doubling in the number of these constructor methods with each additional `FixedSizeArray` type parameter.

I think the code is nicer, too. 