### PR TITLE
fail early for `FixedSizeArray` subtypes we can't handle

### DIFF
--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -144,11 +144,12 @@ end
 Tries to construct a value of type `t` from the iterator `iterator`. The type `t`
 must either be concrete, or a `UnionAll` without constraints.
 """
-function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
+function collect_as(::Type{FSA}, iterator) where {FSA<:FixedSizeArray}
     size_class = Base.IteratorSize(iterator)
     if size_class == Base.IsInfinite()
         throw(ArgumentError("iterator is infinite, can't fit infinitely many elements into a `FixedSizeArray`"))
     end
+    T = check_constructor_is_allowed(FSA)
     mem = parent_type_with_default(T)
     output_dimension_count = checked_dimension_count_of(T, size_class)
     fsv = if (
@@ -163,5 +164,5 @@ function collect_as(::Type{T}, iterator) where {T<:FixedSizeArray}
         fsv  # `size(iterator)` may throw in this branch
     else
         reshape(fsv, size(iterator))
-    end::T
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,7 +491,7 @@ end
                     collect_as(T, iter)
                     true
                 catch e
-                    (e isa TypeError) || rethrow()
+                    (e isa ArgumentError) || rethrow()
                     false
                 end
                 returns && @test collect_as(T, iter) isa T


### PR DESCRIPTION
Before this PR `collect_as` had to use a type assert on the return value to make sure the return value is of the type requested by the user. This is necessary because of UnionAll types with non-default constraints on their type parameters, such as `FixedSizeVector{T} where {T <: Number}`, because accessing the specific constraint is not currently possible in Julia in a supported way.

This change removes the type assert, instead throwing early, as soon as it is recognized that the requested return type is not among the allowed types, which are known-good, in the sense that the return value we produce ends up being of the requested type as expected.

Benefits:
* a type assert of nonconcrete type is not required any more (those can be expensive)
* the throw happens earlier than before

Future PRs will possibly apply the same mechanic to some constructors, in addition to `collect_as`.