### PR TITLE
delete an unnecessary type assert from a `convert` method

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -300,7 +300,7 @@ FixedSizeArray(a::AbstractArray{T,N})          where {T,N} = FixedSizeArray{T,N}
 # conversion
 
 Base.convert(::Type{T}, a::T) where {T<:FixedSizeArray} = a
-Base.convert(::Type{T}, a::AbstractArray) where {T<:FixedSizeArray} = T(a)::T
+Base.convert(::Type{T}, a::AbstractArray) where {T<:FixedSizeArray} = T(a)
 
 # `copyto!`
 


### PR DESCRIPTION
The type assert:
* Is not always concrete, which might cause performance issues.
* Doesn't seem to be necessary, either for good type inference or for correctness.
* If it were necessary, it'd make more sense to insert it earlier, into the body of one of the constructors (which `convert` forwards to).