### PR TITLE
`size` field: allow `Integer` values of singleton type as elements

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -403,12 +403,20 @@ Base.elsize(::Type{A}) where {A<:FixedSizeArray} = Base.elsize(parent_type(A))
 
 # `reshape`: specializing it to ensure it returns a `FixedSizeArray`
 
-function Base.reshape(a::FixedSizeArray, size::(NTuple{N,Int} where {N}))
-    len = checked_dims(size)
+function reshape_fsa(a::FixedSizeArray, size::Tuple{Vararg{Integer}})
+    size_int = normalized_dims(normalized_dim_int, size)
+    len = checked_dims(size_int)
     if length(a) != len
         throw(DimensionMismatch("new shape not consistent with existing array length"))
     end
     new_fixed_size_array(a.mem, size)
+end
+
+function Base.reshape(a::FixedSizeArray, size::Tuple{Vararg{Int}})
+    reshape_fsa(a, size)
+end
+function Base.reshape(a::FixedSizeArray, size::Tuple{Integer, Vararg{Integer}})
+    reshape_fsa(a, size)
 end
 
 # `iterate`: the `AbstractArray` fallback doesn't perform well, so add our own methods

--- a/src/collect_as.jl
+++ b/src/collect_as.jl
@@ -150,6 +150,7 @@ function collect_as(::Type{FSA}, iterator) where {FSA<:FixedSizeArray}
         throw(ArgumentError("iterator is infinite, can't fit infinitely many elements into a `FixedSizeArray`"))
     end
     T = check_constructor_is_allowed(FSA)
+    T = check_size_type(T)
     mem = parent_type_with_default(T)
     output_dimension_count = checked_dimension_count_of(T, size_class)
     fsv = if (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,6 +119,17 @@ end
             let a = FixedSizeArray{Float32}(undef, (big(3), Seven()))
                 @test (3, Seven()) === @inferred size(a)
             end
+            for WrongInt ∈ (UInt, BigInt, Bool)
+                for m ∈ (1, UInt(1), big(1), true)
+                    let elt = Float32
+                        requested_type = FixedSizeVector{elt, Mem{elt}, Tuple{WrongInt}}
+                        @test_throws ArgumentError requested_type(undef, m)
+                        @test_throws ArgumentError requested_type(undef, (m,))
+                        @test_throws ArgumentError requested_type([7])
+                        @test_throws ArgumentError collect_as(requested_type, [7])
+                    end
+                end
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,11 @@ end
                     a = FixedSizeArray{elt}(args...)
                     @test siz === @inferred size(a)
                 end
+                let a = requested_type(undef, 3 * 7)
+                    for args ∈ ((a, siz), (a, siz...))
+                        test_inferred(reshape, return_type, args)
+                    end
+                end
             end
             let a = FixedSizeArray{Float32}(undef, (big(3), big(7)))
                 @test (3, 7) === @inferred size(a)


### PR DESCRIPTION
Currently only `Int` values may be contained in the `size` field. This PR additionally allows values of any singleton type that subtypes `Integer`.

Fixes #54