### PR TITLE
Add faster method for `rand!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,11 @@
 name = "FixedSizeArrays"
 uuid = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
-authors = ["Mosè Giordano <mose@gnu.org>"]
 version = "0.1.0"
+authors = ["Mosè Giordano <mose@gnu.org>"]
+
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+Random = "1"
 julia = "1.10"

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -16,5 +16,6 @@ if isdefined(Base, :dataids) && (Base.dataids isa Function)
 end
 
 include("collect_as.jl")
+include("stdlibs.jl")
 
 end # module FixedSizeArrays

--- a/src/stdlibs.jl
+++ b/src/stdlibs.jl
@@ -3,4 +3,8 @@ using Random: Random
 if isdefined(Base, :Memory)
     Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N,Memory{T}}, sp::Random.Sampler) where {N,T} =
         Random.rand!(rng, A.mem, sp)
+
+    # Method needed only to resolve ambiguities, we don't care too much about it.
+    Random.rand!(r::Random.MersenneTwister, A::FixedSizeArrayDefault{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
+        Random.rand!(r, A.mem, I)
 end

--- a/src/stdlibs.jl
+++ b/src/stdlibs.jl
@@ -1,0 +1,6 @@
+using Random: Random
+
+if isdefined(Base, :Memory)
+    Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N,Memory{T}}, sp::Random.Sampler) where {N,T} =
+        Random.rand!(rng, A.mem, sp)
+end

--- a/src/stdlibs.jl
+++ b/src/stdlibs.jl
@@ -3,6 +3,10 @@ using Random: Random
 Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N}, sp::Random.Sampler) where {N,T} =
     Random.rand!(rng, A.mem, sp)
 
-# Method needed only to resolve ambiguities, we don't care too much about it.
+# Methods needed only to resolve ambiguities, we don't care too much about them
 Random.rand!(r::Random.MersenneTwister, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
     Random.rand!(r, A.mem, I)
+if VERSION < v"1.11"
+    Random.rand!(::Random._GLOBAL_RNG, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
+        Random.rand!(Random.default_rng(), A.mem, I)
+end

--- a/src/stdlibs.jl
+++ b/src/stdlibs.jl
@@ -1,10 +1,8 @@
 using Random: Random
 
-if isdefined(Base, :Memory)
-    Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N,Memory{T}}, sp::Random.Sampler) where {N,T} =
-        Random.rand!(rng, A.mem, sp)
+Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N}, sp::Random.Sampler) where {N,T} =
+    Random.rand!(rng, A.mem, sp)
 
-    # Method needed only to resolve ambiguities, we don't care too much about it.
-    Random.rand!(r::Random.MersenneTwister, A::FixedSizeArrayDefault{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
-        Random.rand!(r, A.mem, I)
-end
+# Method needed only to resolve ambiguities, we don't care too much about it.
+Random.rand!(r::Random.MersenneTwister, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
+    Random.rand!(r, A.mem, I)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,4 +6,5 @@ Test = "1.10"
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -578,14 +578,15 @@ end
     @testset "Random" begin
         for T in (Float16, Float32, Float64),
             N in (4, 16, 64, 128, 256),
-            seed in (17, 42, 123, 5745192337902587512)
+            seed in (17, 42, 123, 5745192337902587512),
+            rng in (Random.default_rng(), Random.MersenneTwister())
 
             v = FixedSizeArrays.default_underlying_storage_type{T}(undef, N)
             fv = FixedSizeVectorDefault{T}(undef, N)
-            Random.seed!(seed)
-            Random.rand!(v)
-            Random.seed!(seed)
-            Random.rand!(fv)
+            rng1 = Random.seed!(rng, seed)
+            Random.rand!(rng1, v)
+            rng2 = Random.seed!(rng, seed)
+            Random.rand!(rng2, fv)
             # Make sure rand!(::FixedSizeArrays) generates same stream of
             # numbers as rand!(::Memory)
             @test v == fv

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using FixedSizeArrays
 using OffsetArrays: OffsetArray
+using Random: Random
 import Aqua
 
 # Check if the compilation options allow maximum performance.
@@ -570,6 +571,27 @@ end
                     @test a == fsa
                     @test first(abstract_array_params(fsa)) <: E
                 end
+            end
+        end
+    end
+
+    @static if isdefined(Base, :Memory)
+        # Tests in this set make sense only when Memory is defined, because rely
+        # on methods defined only for `Memory`.
+        @testset "Random" begin
+            for T in (Float16, Float32, Float64),
+                N in (4, 16, 64, 128, 256),
+                seed in (17, 42, 123, 5745192337902587512)
+
+                v = Memory{T}(undef, N)
+                fv = FixedSizeVectorDefault{T}(undef, N)
+                Random.seed!(seed)
+                Random.rand!(v)
+                Random.seed!(seed)
+                Random.rand!(fv)
+                # Make sure rand!(::FixedSizeArrays) generates same stream of
+                # numbers as rand!(::Memory)
+                @test v == fv
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -575,24 +575,20 @@ end
         end
     end
 
-    @static if isdefined(Base, :Memory)
-        # Tests in this set make sense only when Memory is defined, because rely
-        # on methods defined only for `Memory`.
-        @testset "Random" begin
-            for T in (Float16, Float32, Float64),
-                N in (4, 16, 64, 128, 256),
-                seed in (17, 42, 123, 5745192337902587512)
+    @testset "Random" begin
+        for T in (Float16, Float32, Float64),
+            N in (4, 16, 64, 128, 256),
+            seed in (17, 42, 123, 5745192337902587512)
 
-                v = Memory{T}(undef, N)
-                fv = FixedSizeVectorDefault{T}(undef, N)
-                Random.seed!(seed)
-                Random.rand!(v)
-                Random.seed!(seed)
-                Random.rand!(fv)
-                # Make sure rand!(::FixedSizeArrays) generates same stream of
-                # numbers as rand!(::Memory)
-                @test v == fv
-            end
+            v = FixedSizeArrays.default_underlying_storage_type{T}(undef, N)
+            fv = FixedSizeVectorDefault{T}(undef, N)
+            Random.seed!(seed)
+            Random.rand!(v)
+            Random.seed!(seed)
+            Random.rand!(fv)
+            # Make sure rand!(::FixedSizeArrays) generates same stream of
+            # numbers as rand!(::Memory)
+            @test v == fv
         end
     end
 end


### PR DESCRIPTION
The `rand!` method for `Memory` is vectorized and faster than the generic method for `AbstractArray` (which is the one currently being hit by `FixedSizeArray`s) at least for sufficiently long vectors.

I spotted this while looking into performance differences in https://github.com/JuliaArrays/FixedSizeArrays.jl/discussions/62#discussioncomment-12319065.