### PR TITLE
introduce `BoundsErrorLight`, use instead of `BoundsError`

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -14,6 +14,7 @@ FixedSizeArrayDefault
 FixedSizeVectorDefault
 FixedSizeMatrixDefault
 FixedSizeArrays.collect_as
+BoundsErrorLight
 ```
 
 ## Internal API

--- a/src/BoundsErrorLight.jl
+++ b/src/BoundsErrorLight.jl
@@ -11,18 +11,6 @@ struct BoundsErrorLight <: Exception
     index::Int
 end
 
-function show_index(io::IO, x)
-    if x isa Colon
-        print(io, ':')
-    elseif x isa Base.OneTo
-        print(io, "1:")
-        show(io, last(x))
-    else
-        show(io, x)
-    end
-    nothing
-end
-
 function Base.showerror(io::IO, ex::BoundsErrorLight)
     typ = ex.type_of_array
     shp = ex.shape
@@ -32,16 +20,7 @@ function Base.showerror(io::IO, ex::BoundsErrorLight)
     print(io, " and shape ")
     show(io, shp)
     print(io, " at index [")
-    if (ind isa AbstractRange) || (ind isa AbstractString)
-        show(io, ind)
-    else
-        for (i, x) ∈ enumerate(ind)
-            if 1 < i
-                print(io, ", ")
-            end
-            show_index(io, x)
-        end
-    end
+    show(io, ind)
     print(io, ']')
     nothing
 end

--- a/src/BoundsErrorLight.jl
+++ b/src/BoundsErrorLight.jl
@@ -50,11 +50,11 @@ end
 
 function throw_boundserrorlight(A::AbstractArray, i::Int)
     @inline
-    @inline throw(BoundsErrorLight(typeof(A), size(A), i))
+    throw(BoundsErrorLight(typeof(A), size(A), i))
 end
 
 function check_bounds_light(A::AbstractArray, i::Int)
     @inline
-    @inline checkbounds(Bool, A, i) || @inline throw_boundserrorlight(A, i)
+    checkbounds(Bool, A, i) || throw_boundserrorlight(A, i)
     nothing
 end

--- a/src/BoundsErrorLight.jl
+++ b/src/BoundsErrorLight.jl
@@ -1,0 +1,58 @@
+"""
+    BoundsErrorLight <: Exception
+
+Like `BoundsError`, but doesn't store the array, to prevent clashing with escape analysis.
+
+Stores the type of the array and the shape instead.
+"""
+struct BoundsErrorLight <: Exception
+    type_of_array::DataType
+    shape::Tuple{Vararg{Int}}
+    index::Int
+end
+
+function show_index(io::IO, x)
+    if x isa Colon
+        print(io, ':')
+    elseif x isa Base.OneTo
+        print(io, "1:")
+        show(io, last(x))
+    else
+        show(io, x)
+    end
+    nothing
+end
+
+function Base.showerror(io::IO, ex::BoundsErrorLight)
+    typ = ex.type_of_array
+    shp = ex.shape
+    ind = ex.index
+    print(io, "BoundsErrorLight: attempt to access array of type ")
+    show(io, typ)
+    print(io, " and shape ")
+    show(io, shp)
+    print(io, " at index [")
+    if (ind isa AbstractRange) || (ind isa AbstractString)
+        show(io, ind)
+    else
+        for (i, x) ∈ enumerate(ind)
+            if 1 < i
+                print(io, ", ")
+            end
+            show_index(io, x)
+        end
+    end
+    print(io, ']')
+    nothing
+end
+
+function throw_boundserrorlight(A::AbstractArray, i::Int)
+    @noinline
+    throw(BoundsErrorLight(typeof(A), size(A), i))
+end
+
+function check_bounds_light(A::AbstractArray, i::Int)
+    @inline
+    checkbounds(Bool, A, i) || @noinline throw_boundserrorlight(A, i)
+    nothing
+end

--- a/src/BoundsErrorLight.jl
+++ b/src/BoundsErrorLight.jl
@@ -46,13 +46,15 @@ function Base.showerror(io::IO, ex::BoundsErrorLight)
     nothing
 end
 
+# inline everything to help escape analysis
+
 function throw_boundserrorlight(A::AbstractArray, i::Int)
-    @noinline
-    throw(BoundsErrorLight(typeof(A), size(A), i))
+    @inline
+    @inline throw(BoundsErrorLight(typeof(A), size(A), i))
 end
 
 function check_bounds_light(A::AbstractArray, i::Int)
     @inline
-    checkbounds(Bool, A, i) || @noinline throw_boundserrorlight(A, i)
+    @inline checkbounds(Bool, A, i) || @inline throw_boundserrorlight(A, i)
     nothing
 end

--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -1,4 +1,5 @@
 export
+    BoundsErrorLight,
     FixedSizeArray, FixedSizeVector, FixedSizeMatrix,
     FixedSizeArrayDefault, FixedSizeVectorDefault, FixedSizeMatrixDefault
 
@@ -164,9 +165,12 @@ macro assume_noub_if_noinbounds(x)
 end
 
 Base.IndexStyle(::Type{<:FixedSizeArray}) = IndexLinear()
-Base.@propagate_inbounds Base.getindex(A::FixedSizeArray, i::Int) = A.mem[i]
+Base.@propagate_inbounds function Base.getindex(A::FixedSizeArray, i::Int)
+    @boundscheck check_bounds_light(A, i)
+    @inbounds A.mem[i]
+end
 Base.@propagate_inbounds @assume_noub_if_noinbounds function Base.setindex!(A::FixedSizeArray, x, i::Int)
-    @boundscheck checkbounds(A, i)
+    @boundscheck check_bounds_light(A, i)
     @inbounds A.mem[i] = x
     return A
 end

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -1,5 +1,7 @@
 module FixedSizeArrays
 
+include("BoundsErrorLight.jl")
+
 const default_underlying_storage_type = (@isdefined Memory) ? Memory : Vector
 
 const optional_memory = (@isdefined Memory) ? (Memory,) : ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,7 +250,18 @@ end
             v[2] = 2
             @test v[1] == 1
             @test v[2] == 2
-            @test_throws BoundsError v[3] = 3
+        end
+
+        @testset "out-of-bounds access" begin
+            v0 = FSV([])
+            v1 = FSV([3])
+            @test_throws BoundsErrorLight v0[1]
+            @test_throws BoundsErrorLight v1[2]
+            @test_throws BoundsErrorLight v0[1] = 7
+            @test_throws BoundsErrorLight v1[2] = 7
+            exc_text = sprint(showerror, BoundsErrorLight(typeof(v1), size(v1), 2))
+            @test startswith(exc_text, "BoundsErrorLight: ")
+            @test endswith(exc_text, "[2]")
         end
 
         @testset "FixedSizeVector" begin


### PR DESCRIPTION
Unlike `BoundsError`, `BoundsErrorLight` doesn't store the array, potentially helping escape analysis.