### PR TITLE
add method for `getindex(::FixedSizeArray, ::Colon)`

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -343,6 +343,12 @@ function Base.copy(a::FixedSizeArray)
     new_fixed_size_array(copy(Base.parent(a)), size(a))
 end
 
+# `getindex` with a `Colon` for the index: better effects than with the generic fallback
+
+function Base.getindex(a::FixedSizeArray, ::Colon)
+    copy(a)
+end
+
 # `copyto!`
 
 Base.@propagate_inbounds function copyto5!(dst, doff, src, soff, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -403,6 +403,8 @@ end
             m = FixedSizeArray(rand(2, 2))::FixedSizeArray
             @test m == copy(m)
             @test m !== copy(m)
+            @test m == m[:]
+            @test m !== m[:]
         end
 
         @testset "`copyto!`" begin


### PR DESCRIPTION
Merely forwarding to `copy` results in better effect inference, we get `nothrow` and `terminates`.

Fixes #117