### PR TITLE
avoid possibly costly `typeassert`

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -294,7 +294,6 @@ function with_stripped_type_parameters(spec, t::Type)
     ret = with_stripped_type_parameters_unchecked(spec, t)
     s = val_parameter(ret)
     s = s::UnionAll
-    s = s::(Type{T} where {T>:t})
     Val{s}()
 end
 


### PR DESCRIPTION
As far as I understand, a `typeassert` is zero-cost when the RHS is known upfront and concrete. Otherwise it can be costly, assuming it's not just optimized out.