### PR TITLE
Bump version number to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version [v1.0.0](https://github.com/JuliaArrays/FixedSizeArrays.jl/releases/tag/v1.0.0) - 2025-06-??
+## Version [v1.0.0](https://github.com/JuliaArrays/FixedSizeArrays.jl/releases/tag/v1.0.0) - 2025-06-04
 
 Initial release.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedSizeArrays"
 uuid = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
-version = "0.1.0"
-authors = ["Mosè Giordano <mose@gnu.org>"]
+version = "1.0.0"
+authors = ["Mosè Giordano <mose@gnu.org>, Neven Sajko <s@purelymail.com>, Oscar Smith <oscar.smith@juliacomputing.com>, and contributors"]
 
 [deps]
 Collects = "08986516-18db-4a8b-8eaa-f5ef1828d8f1"


### PR DESCRIPTION
I think we're done with #115 and we can go on with first release.  Objections?  Also, I propose using version v1.0, if you're happy with it.

Fix #115