### PR TITLE
Make `rand!(A::FixedSizeArray)` return `A` instead of its parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v1.0.1](https://github.com/JuliaArrays/FixedSizeArrays.jl/releases/tag/v1.0.1) - 2025-06-08
+
+### Fixed
+
+* `rand!(A::FixedSizeArray)` now returns `A`, instead of its parent. ([#139](https://github.com/JuliaArrays/FixedSizeArrays.jl/issues/139), [#140](https://github.com/JuliaArrays/FixedSizeArrays.jl/pull/140))
+
 ## Version [v1.0.0](https://github.com/JuliaArrays/FixedSizeArrays.jl/releases/tag/v1.0.0) - 2025-06-04
 
 Initial release.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedSizeArrays"
 uuid = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Mosè Giordano <mose@gnu.org>, Neven Sajko <s@purelymail.com>, Oscar Smith <oscar.smith@juliacomputing.com>, and contributors"]
 
 [deps]

--- a/ext/RandomExt.jl
+++ b/ext/RandomExt.jl
@@ -3,15 +3,22 @@ module RandomExt
 using Random: Random
 using FixedSizeArrays: FixedSizeArray
 
-Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N}, sp::Random.Sampler) where {N,T} =
+function Random.rand!(rng::Random.AbstractRNG, A::FixedSizeArray{T,N}, sp::Random.Sampler) where {N,T}
     Random.rand!(rng, parent(A), sp)
+    return A
+end
 
 # Methods needed only to resolve ambiguities, we don't care too much about them
-Random.rand!(r::Random.MersenneTwister, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
+function Random.rand!(r::Random.MersenneTwister, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N}
     Random.rand!(r, parent(A), I)
+    return A
+end
+
 if VERSION < v"1.11"
-    Random.rand!(::Random._GLOBAL_RNG, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N} =
+    function Random.rand!(::Random._GLOBAL_RNG, A::FixedSizeArray{Float64,N}, I::Random.SamplerTrivial{<:Random.FloatInterval{Float64}}) where {N}
         Random.rand!(Random.default_rng(), parent(A), I)
+        return A
+    end
 end
 
 end # module RandomExt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -631,7 +631,8 @@ end
             rng1 = Random.seed!(rng, seed)
             Random.rand!(rng1, v)
             rng2 = Random.seed!(rng, seed)
-            Random.rand!(rng2, fv)
+            # Make sure `rand!` returns `fv` itself.
+            @test Random.rand!(rng2, fv) === fv
             # Make sure rand!(::FixedSizeArrays) generates same stream of
             # numbers as rand!(::Memory)
             @test v == fv


### PR DESCRIPTION
Fix #139.  This is very technically breaking, but I'm considering it a bugfix, it's unlikely someone over the last day since the package was first released was already relying on an unexpected behaviour.  CC @jakobnissen
