### PR TITLE
Add Adapt.jl package extension to construct FixedSizeArrays which preserve wrapper types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,14 @@ Collects = "08986516-18db-4a8b-8eaa-f5ef1828d8f1"
 
 [weakdeps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [extensions]
 RandomExt = "Random"
+AdaptExt = "Adapt"
 
 [compat]
+Adapt = "4"
 Collects = "1"
 Random = "1"
 julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Collects = "08986516-18db-4a8b-8eaa-f5ef1828d8f1"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -8,6 +9,7 @@ FixedSizeArrays = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
 FixedSizeArrays = {path = ".."}
 
 [compat]
+Adapt = "4"
 Changelog = "1.1"
 Collects = "1"
 Documenter = "1"

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -34,6 +34,22 @@ julia> FixedSizeArray{Float64}(arr)  # construct from an `AbstractArray` value w
  30.0  14.0
 ```
 
+To "convert" a wrapper type like `Adjoint` while preserving the wrapper structure, you can use `Adapt`:
+
+```jldoctest
+julia> using FixedSizeArrays, Adapt
+
+julia> arr = transpose([10 20; 30 14])
+2×2 transpose(::Matrix{Int64}) with eltype Int64:
+ 10  30
+ 20  14
+
+julia> adapt(FixedSizeArray, arr)
+2×2 transpose(::FixedSizeArray{Int64, 2, Memory{Int64}}) with eltype Int64:
+ 10  30
+ 20  14
+```
+
 For 1- and 2-dimensional arrays you can use the aliases [`FixedSizeVector`](@ref) and [`FixedSizeMatrix`](@ref), respectively:
 
 ```@repl

--- a/ext/AdaptExt.jl
+++ b/ext/AdaptExt.jl
@@ -1,0 +1,8 @@
+module AdaptExt
+
+using Adapt
+using FixedSizeArrays: FixedSizeArray
+
+Adapt.adapt_storage(fixed::Type{<:FixedSizeArray}, A) = fixed(A) 
+
+end # module AdaptExt

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,13 +1,17 @@
 [compat]
+Adapt = "4"
 Aqua = "0.8"
 Collects = "1"
+LinearAlgebra = "1"
 OffsetArrays = "1.14"
 Random = "1.10"
 Test = "1.10"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Collects = "08986516-18db-4a8b-8eaa-f5ef1828d8f1"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using LinearAlgebra, Adapt
 using FixedSizeArrays
 using Collects: collect_as
 using OffsetArrays: OffsetArray
@@ -668,5 +669,13 @@ end
             # numbers as rand!(::Memory)
             @test v == fv
         end
+    end
+
+    @testset "Adapt" begin
+        # Preserver wrapper types:
+        arr = transpose([10 20; 30 14])
+        farr = adapt(FixedSizeArray, arr)
+        @test farr isa Transpose
+        @test parent(farr) isa FixedSizeArray
     end
 end


### PR DESCRIPTION
Hello, I was playing around with this package and in my use cases we have a lot of wrapper types around arrays, where we want to preserve the wrapper. We commonly do that with `Adapt.jl`, so far mostly to move things to the GPU. But we could also use it to move things from `Array` to `FixedSizeArray` with this PR:

```julia
julia> using FixedSizeArrays, Adapt

julia> arr = transpose([10 20; 30 14])
2×2 transpose(::Matrix{Int64}) with eltype Int64:
 10  30
 20  14

julia> FixedSizeArray(arr)
2×2 FixedSizeArray{Int64, 2, Memory{Int64}}:
 10  30
 20  14

julia> adapt(FixedSizeArray, arr) # without the extensions this would still be typeof(arr)
2×2 transpose(::FixedSizeArray{Int64, 2, Memory{Int64}}) with eltype Int64:
 10  30
 20  14
 ```
 
 I can also turn the example into a test if this PR is interesting for FixedSizeArrays
 