### PR TITLE
allow constant-prop through `iterate`

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -404,9 +404,9 @@ function Base.reshape(a::FixedSizeArray, size::(NTuple{N,Int} where {N}))
     new_fixed_size_array(parent(a), size)
 end
 
-# `iterate`: the `AbstractArray` fallback doesn't perform well, so add our own methods
+# `iterate`: the `AbstractArray` fallback doesn't perform well, so add our own methods (copied from `Base.Array`)
 
-iterate(A::FixedSizeArray, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
+Base.iterate(A::FixedSizeArray, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
 
 """
     FixedSizeArrayDefault{T,N}(undef, size::NTuple{N,Int})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -706,6 +706,6 @@ end
             m[2] = 2
             m[3] = 3
             tuple(m...)
-       end[] == NTuple{3, Int} broken = VERSION < v"1.12-"
+       end[] == NTuple{3, Int}
     end
 end


### PR DESCRIPTION
Allows inference to unroll `iterate` for a `FixedSizeArray` with statically known size