### PR TITLE
Disambiguate names of extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [extensions]
-RandomExt = "Random"
-AdaptExt = "Adapt"
+FixedSizeArraysRandomExt = "Random"
+FixedSizeArraysAdaptExt = "Adapt"
 
 [compat]
 Adapt = "4"

--- a/ext/FixedSizeArraysAdaptExt.jl
+++ b/ext/FixedSizeArraysAdaptExt.jl
@@ -1,8 +1,8 @@
-module AdaptExt
+module FixedSizeArraysAdaptExt
 
 using Adapt
 using FixedSizeArrays: FixedSizeArray
 
 Adapt.adapt_storage(fixed::Type{<:FixedSizeArray}, A) = fixed(A) 
 
-end # module AdaptExt
+end # module FixedSizeArraysAdaptExt

--- a/ext/FixedSizeArraysRandomExt.jl
+++ b/ext/FixedSizeArraysRandomExt.jl
@@ -1,4 +1,4 @@
-module RandomExt
+module FixedSizeArraysRandomExt
 
 using Random: Random
 using FixedSizeArrays: FixedSizeArray
@@ -21,4 +21,4 @@ if VERSION < v"1.11"
     end
 end
 
-end # module RandomExt
+end # module FixedSizeArraysRandomExt


### PR DESCRIPTION
This should be a non-functional change, but only avoid clashes with similarly named extensions in other packages.