### PR TITLE
test: start covering destructuring

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,10 +309,10 @@ end
             mat = FSM(rand(3, 3))
             @testset "`Base.rest`" begin
                 @test let (v...,) = vec
-                    v isa FSV
+                    v isa AbstractVector
                 end
                 @test let (v...,) = mat
-                    v isa FSV
+                    v isa AbstractVector
                 end
                 @test let (v...,) = vec
                     v == vec


### PR DESCRIPTION
Specifically, this only covers `Base.rest`. Neither `Base.split_rest` nor `Base.indexed_iterate` are covered with this PR.