### PR TITLE
test: add noalloc tests sourced from showcase discussions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,6 +160,11 @@ end
         @test_throws MethodError FixedSizeMatrix(undef, 1, 1)
     end
 
+    # only run this testset when:
+    #
+    # * Julia is new enough for `Memory` to be available
+    #
+    # * bounds-checking is not forced on (so `--check-bounds=auto` or `--check-bounds=no`, but not `--check-bounds=yes`)
     (@isdefined Memory) && (Base.JLOptions().check_bounds != 1) &&
     @testset "examples of heap allocation being optimized out" begin
         # source for some/all of these: https://github.com/JuliaArrays/FixedSizeArrays.jl/discussions/62


### PR DESCRIPTION
The new tests do not run with the usual CI configuration that uses `--check-bounds=yes` (as they would fail with bounds checking forced on), but they do run with CI jobs that use `--check-bounds=auto`.