### PR TITLE
Move isassigned boundscheck to FSA wrapper

### DIFF
--- a/src/FixedSizeArray.jl
+++ b/src/FixedSizeArray.jl
@@ -184,7 +184,10 @@ function Base.similar(::T, ::Type{E}, size::NTuple{N,Int}) where {T<:FixedSizeAr
     S(undef, size)
 end
 
-Base.isassigned(a::FixedSizeArray, i::Int) = isassigned(parent(a), i)
+function Base.isassigned(a::FixedSizeArray, i::Int)
+    @boundscheck checkbounds(Bool, a, i) || return false
+    @inbounds isassigned(parent(a), i)
+end
 
 # safe product of a tuple of integers, for calculating dimensions size
 


### PR DESCRIPTION
In Base.boundscheck, instead of forwarding boundscheck to the inner vector, do the boundscheck on the wrapper FSA, and then call inner isassigned with @inbounds.
This allows correct results for unsafe inner arrays which does not, or cannot boundscheck.
In general, it would be preferred for FSA to check indices where possible, since the FSA wrapper "owns" the indices.